### PR TITLE
rev666 esp8266 support on sensorlib and Panasonic issue resolved

### DIFF
--- a/lib/gui-utils/src/GUIUtils.cpp
+++ b/lib/gui-utils/src/GUIUtils.cpp
@@ -38,7 +38,7 @@ void GUIUtils::showWelcome() {
     u8g2.drawStr(46, 1, getFirmwareVersionCode().c_str());
     u8g2.drawLine(0, 9, 63, 9);
     u8g2.sendBuffer();
-    lastDrawedLine = 12;
+    lastDrawedLine = 10;
     // only for first screen
     u8g2.sendBuffer();
 }
@@ -52,6 +52,10 @@ void GUIUtils::showProgress(unsigned int progress, unsigned int total) {
 }
 
 void GUIUtils::welcomeAddMessage(String msg) {
+    if(lastDrawedLine >=45) {
+        delay(2000);
+        showWelcome();
+    }
     u8g2.setFont(u8g2_font_4x6_tf);
 #ifdef TTGO_TQ
     if (lastDrawedLine < 32) {
@@ -68,6 +72,7 @@ void GUIUtils::welcomeAddMessage(String msg) {
     lastDrawedLine = lastDrawedLine + 7;
     u8g2.sendBuffer();
 #endif
+    delay(500);
 }
 
 void GUIUtils::welcomeRepeatMessage(String msg) {

--- a/lib/gui-utils/src/GUIUtils.cpp
+++ b/lib/gui-utils/src/GUIUtils.cpp
@@ -72,7 +72,7 @@ void GUIUtils::welcomeAddMessage(String msg) {
     lastDrawedLine = lastDrawedLine + 7;
     u8g2.sendBuffer();
 #endif
-    delay(500);
+    delay(200);
 }
 
 void GUIUtils::welcomeRepeatMessage(String msg) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
     -D CORE_DEBUG_LEVEL=0
-    -D SRC_REV=661
+    -D SRC_REV=666
     -D EMOTICONS          ; Big emoticons, text and color visualization
     ; -D FORCE_WATCHDOG   ; Force device to reboot each some time.
     ; -D DEBUG_ESP_WIFI
@@ -20,7 +20,8 @@ lib_deps =
     U8g2
     ArduinoJson
     https://github.com/hpsaturn/Influx-Arduino.git
-    hpsaturn/CanAirIO Air Quality Sensors Library
+    ; hpsaturn/CanAirIO Air Quality Sensors Library
+    https://github.com/kike-canaries/canairio_sensorlib.git#esp8266
 
 # variant for official guide via OTA:
 # TTGO T7 v1.3 mini board (d1mini v2) and Panasonic sensor

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
     -D CORE_DEBUG_LEVEL=0
-    -D SRC_REV=666
+    -D SRC_REV=667
     -D EMOTICONS          ; Big emoticons, text and color visualization
     ; -D FORCE_WATCHDOG   ; Force device to reboot each some time.
     ; -D DEBUG_ESP_WIFI
@@ -20,8 +20,8 @@ lib_deps =
     U8g2
     ArduinoJson
     https://github.com/hpsaturn/Influx-Arduino.git
-    ; hpsaturn/CanAirIO Air Quality Sensors Library
-    https://github.com/kike-canaries/canairio_sensorlib.git#esp8266
+    hpsaturn/CanAirIO Air Quality Sensors Library
+    ; https://github.com/kike-canaries/canairio_sensorlib.git#esp8266
 
 # variant for official guide via OTA:
 # TTGO T7 v1.3 mini board (d1mini v2) and Panasonic sensor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ void startingSensors() {
     gui.welcomeAddMessage("Detected sensor:");
     sensors.setOnDataCallBack(&onSensorDataOk);   // all data read callback
     sensors.setSampleTime(cfg.stime);             // config sensors sample time
-    sensors.setDebugMode(true);                  // [optional] debug mode
+    sensors.setDebugMode(false);                  // [optional] debug mode
     sensors.init(cfg.getSensorType());            // start all sensors and
                                                   // try to detect configured PM sensor.
                                                   // Sensors supported: Panasonic, Honeywell, Plantower and Sensirion
@@ -127,7 +127,7 @@ void setup() {
     gui.welcomeAddMessage("stime: "+String(cfg.stime)+ " sec.");
 
     gui.welcomeAddMessage("==SETUP READY==");
-    delay(3000);
+    delay(1000);
 
     // display main screen
     displayGUI();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,8 @@ void onSensorDataError(const char * msg){
 }
 
 void startingSensors() {
-    gui.welcomeAddMessage("Detecting sensors..");
     Serial.println("-->[INFO] PM sensor configured: "+String(cfg.stype));
+    gui.welcomeAddMessage("Detected sensor:");
     sensors.setOnDataCallBack(&onSensorDataOk);   // all data read callback
     sensors.setSampleTime(cfg.stime);             // config sensors sample time
     sensors.setDebugMode(true);                  // [optional] debug mode
@@ -42,11 +42,11 @@ void startingSensors() {
     if(sensors.isPmSensorConfigured()){
         Serial.print("-->[INFO] PM sensor detected: ");
         Serial.println(sensors.getPmDeviceSelected());
-        gui.welcomeRepeatMessage(sensors.getPmDeviceSelected());
+        gui.welcomeAddMessage(sensors.getPmDeviceSelected());
     }
     else {
         Serial.println("-->[INFO] Detection sensors FAIL!");
-        gui.welcomeRepeatMessage("Detection !FAIL!");
+        gui.welcomeAddMessage("Detection !FAILED!");
     }
 }
 
@@ -93,8 +93,7 @@ void setup() {
     // init all sensors
     Serial.println("-->[INFO] Detecting sensors..");
     startingSensors();
-    delay(500);
-    
+
     // init battery (only for some boards)
     batteryInit();
 
@@ -104,20 +103,31 @@ void setup() {
 
     // WiFi and cloud communication
     wifiInit();
+    Serial.println("-->[INFO] InfluxDb API:\t" + String(cfg.isIfxEnable()));
+    Serial.println("-->[INFO] CanAirIO API:\t" + String(cfg.isApiEnable()));
+    gui.welcomeAddMessage("CanAirIO API:"+String(cfg.isApiEnable()));
+    gui.welcomeAddMessage("InfluxDb :"+String(cfg.isIfxEnable()));
+    influxDbInit();
+    apiInit();  // DEPRECATED
+
+    // init watchdog timer for reboot in any loop blocker
+    wd.init();
+    gui.welcomeAddMessage("Watchdog ready");
+
+    // mac address
+    gui.welcomeAddMessage(cfg.getDeviceId());
+
+    // wifi status 
     if (WiFi.isConnected())
         gui.welcomeAddMessage("WiFi:" + cfg.ssid);
     else
         gui.welcomeAddMessage("WiFi: disabled.");
-    Serial.println("-->[INFO] InfluxDb API:\t" + String(cfg.isIfxEnable()));
-    Serial.println("-->[INFO] CanAirIO API:\t" + String(cfg.isApiEnable()));
-    influxDbInit();
-    apiInit();  // DEPRECATED
-    if (WiFi.isConnected()) gui.welcomeAddMessage("API clouds ready.");
 
-    // init watchdog timer for reboot in any loop blocker
-    wd.init();
+    // sensor sample time and publish time (2x)
+    gui.welcomeAddMessage("stime: "+String(cfg.stime)+ " sec.");
+
     gui.welcomeAddMessage("==SETUP READY==");
-    delay(4000);
+    delay(3000);
 
     // display main screen
     displayGUI();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ void startingSensors() {
     Serial.println("-->[INFO] PM sensor configured: "+String(cfg.stype));
     sensors.setOnDataCallBack(&onSensorDataOk);   // all data read callback
     sensors.setSampleTime(cfg.stime);             // config sensors sample time
-    sensors.setDebugMode(false);                  // [optional] debug mode
+    sensors.setDebugMode(true);                  // [optional] debug mode
     sensors.init(cfg.getSensorType());            // start all sensors and
                                                   // try to detect configured PM sensor.
                                                   // Sensors supported: Panasonic, Honeywell, Plantower and Sensirion

--- a/test_sensorlib/platformio.ini
+++ b/test_sensorlib/platformio.ini
@@ -17,16 +17,10 @@ framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
-    -D SRC_REV=001
-    -D CORE_DEBUG_LEVEL=0
-    ; -D EMOTICONS          ; Big emoticons, text and color visualization
-    ; -D FORCE_WATCHDOG   ; Force device to reboot each some time.
-    ; -D DEBUG_ESP_WIFI
+    -D SRC_REV=088
+    -D CORE_DEBUG_LEVEL=5
 lib_deps =
-    Adafruit Unified Sensor
-    Adafruit AM2320 sensor library
-    sps30
-    https://github.com/kike-canaries/canairio_sensorlib.git
+    hpsaturn/CanAirIO Air Quality Sensors Library
 
 # variant for official guide:
 # TTGO T7 v1.3 mini board (d1mini v2) and Panasonic sensor
@@ -39,5 +33,15 @@ monitor_speed = ${common_env_data.monitor_speed}
 lib_deps = ${common_env_data.lib_deps}
 build_flags =
     ${common_env_data.build_flags}
+
+[env:esp12e]
+platform = espressif8266
+framework = ${common_env_data.framework}
+board = esp12e
+monitor_speed = ${common_env_data.monitor_speed}
+build_flags =
+      ${common_env_data.build_flags}
+lib_deps = 
+      ${common_env_data.lib_deps}
 
 

--- a/test_sensorlib/src/main.cpp
+++ b/test_sensorlib/src/main.cpp
@@ -15,6 +15,10 @@ void onSensorDataOk() {
     Serial.println(" PM10: " + sensors.getStringPM10());
 }
 
+void onSensorDataError(const char * msg){
+    Serial.println(msg);
+}
+
 /******************************************************************************
 *  M A I N
 ******************************************************************************/
@@ -24,9 +28,20 @@ void setup() {
     delay(200);
     Serial.println("\n== Sensor test setup ==\n");
 
-    sensors.setOnDataCallBack(&onSensorDataOk);  // all data read callback
+    Serial.println("-->[SETUP] Detecting sensors..");
+
     sensors.setSampleTime(5);                       // config sensors sample time interval
-    sensors.init(sensors.Sensirion);                // start all sensors and force to PM sensor to Sensirion
+    sensors.setOnDataCallBack(&onSensorDataOk);     // all data read callback
+    sensors.setOnErrorCallBack(&onSensorDataError); // [optional] error callback
+    sensors.setDebugMode(true);                    // [optional] debug mode
+
+    // sensors.init();                              // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
+    // sensors.init(sensors.Auto);                  // Auto detection of PM sensors (Honeywell, Plantower, Panasonic)
+    // sensors.init(sensors.Panasonic);             // Force detection to Panasonic sensor
+    // sensors.init(sensors.Sensirion);             // Force detection to Sensirion sensor
+    // sensors.init(sensors.Auto,mRX,mTX);          // Auto detection and custom RX, TX pines
+
+    sensors.init();
 
     if(sensors.isPmSensorConfigured())
         Serial.println("-->[SETUP] Sensor configured: " + sensors.getPmDeviceSelected());


### PR DESCRIPTION
## Description

- [x] tested on esp32 the new version of CanAirIO sensorlib with Panasonic, Sensirion and Plantower
- [x] compiled and installing ok over esp8266
- [x] some UART issues fixed for Panasonic and Sensirion
- [x] autodetection for Plantower, Panasonic and Honeywell working fine in auto mode
 
## TODO

- [ ] run all tests over esp8266 with all sensors

 