### PR TITLE
Select Python3 when possible.

### DIFF
--- a/releases/installer/canairio_installer/install.sh
+++ b/releases/installer/canairio_installer/install.sh
@@ -40,18 +40,18 @@ showHelp () {
 }
 
 flashOTA () {
-  ./system/espota.py --port=3232 --auth=CanAirIO --debug --progress -i $2 -f $1
+  $PYTHON ./system/espota.py --port=3232 --auth=CanAirIO --debug --progress -i $2 -f $1
 }
 
 flash () {
-  ./system/esptool.py --chip esp32 --port $2 --baud $3 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 system/bootloader_dio_40m.bin 0x8000 system/partitions.bin 0xe000 system/boot_app0.bin 0x10000 $1
+  $PYTHON ./system/esptool.py --chip esp32 --port $2 --baud $3 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 system/bootloader_dio_40m.bin 0x8000 system/partitions.bin 0xe000 system/boot_app0.bin 0x10000 $1
 }
 
 erase_flash () {
     if ! [[ -z "$2" ]]; then
       USBPORT="$2"
     fi
-    ./system/esptool.py --port $USBPORT erase_flash
+    $PYTHON ./system/esptool.py --port $USBPORT erase_flash
 }
 
 printParams() {

--- a/releases/installer/canairio_installer/install.sh
+++ b/releases/installer/canairio_installer/install.sh
@@ -5,6 +5,11 @@ OTAHOSTIP="'CanAirIO.local'"
 USBPORT="/dev/ttyUSB0"
 USBSPEED="115200"
 
+PYTHON="$(command -v python)"
+if [ -x "$(command -v python3)" ]; then
+  echo 'Selecting python3' >&2
+fi
+
 showHelp () {
   echo ""
   echo "usage: ./install.sh [binary]"


### PR DESCRIPTION
For some reason I couldn't find the python serial module for python2
and I noticed people are doing weird stuff when this happens in Ubuntu
20.04.

https://github.com/espressif/esptool/issues/528

The proposal is to select python3 when possible. For me the upload tool
worked.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR.