### PR TITLE
Deep sleep first test

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,9 @@
 #include <bluetooth.hpp>
 #include <wifi.hpp>
 
+#include <power.h>
+#define LORA_TX_INTERVAL 300
+
 void refreshGUIData() {
     gui.displaySensorLiveIcon();  // all sensors read are ok
     int deviceType = sensors.getPmDeviceTypeSelected();
@@ -133,6 +136,12 @@ void setup() {
     delay(400);
     Serial.println("\n== CanAirIO Setup ==\n");
 
+     //if( ReadVBat() < 3300)
+    //{
+    //   Serial.println("Goto DeepSleep (VBat to low)");
+    //   PowerDeepSleepTimer(LORA_TX_INTERVAL);
+    //}
+    
     // init app preferences and load settings
     cfg.init("canairio");
 
@@ -209,4 +218,7 @@ void loop() {
     wd.loop();       // watchdog for check loop blockers
                      // update GUI flags:
     gui.setGUIStatusFlags(WiFi.isConnected(), true, bleIsConnected());
+    
+    PowerDeepSleepTimer(LORA_TX_INTERVAL - 30 - 8); // 30sec for SDS011, 8 sec for remaining code 
+    
 }

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -1,0 +1,16 @@
+#include <power.h>
+#include <driver/adc.h>
+
+void PowerDeepSleepTimer(int seconds)
+{
+    esp_sleep_enable_timer_wakeup(seconds * 1000000);
+    esp_deep_sleep_start();
+}
+
+void PowerLightSleepTimer(int seconds)
+{
+    adc_power_off();
+
+    esp_sleep_enable_timer_wakeup(seconds * 1000000);
+    esp_light_sleep_start();
+}

--- a/src/power.h
+++ b/src/power.h
@@ -1,0 +1,10 @@
+#pragma once
+#ifndef _POWER_H
+#define _POWER_H
+
+#include <Arduino.h>
+
+void PowerDeepSleepTimer(int);
+void PowerLightSleepTimer(int);
+
+#endif


### PR DESCRIPTION
T7 ver 1.3 with oled and Panasonic PM sensor.
The board go to deep sleep for 300 seg and then  wake up, colect the data, show on the oled and go to sleep again.
Sleep timer is called Lora thinking in the future use of LORA. There is a repo in github that use LORA with deep sleep.
Problems: 
BLE has not time to connect with the app. It Is neccesary a configutation time on  first start up in order to change the config.
Pax counter  is stopped and restarted with each wake-up. sniffs only one channel at a time


