### PR TITLE
Canairio solar version

### DIFF
--- a/lib/batterylib/battery_oled.cpp
+++ b/lib/batterylib/battery_oled.cpp
@@ -4,7 +4,37 @@
 #ifndef M5STICKCPLUS
   #ifndef TTGO_TDISPLAY
 
+int vref = 1086;
+float curv = 0;
+
+void setupBattADC() {
+    esp_adc_cal_characteristics_t adc_chars;
+    esp_adc_cal_value_t val_type = esp_adc_cal_characterize((adc_unit_t)ADC_UNIT_1, (adc_atten_t)ADC1_CHANNEL_6, (adc_bits_width_t)ADC_WIDTH_BIT_12, 1100, &adc_chars);
+    //Check type of calibration value used to characterize ADC
+    if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
+        Serial.printf("-->[BATT] ADC eFuse Vref:%u mV\n", adc_chars.vref);
+        vref = adc_chars.vref;
+    } else if (val_type == ESP_ADC_CAL_VAL_EFUSE_TP) {
+        Serial.printf("-->[BATT] ADC Two Point --> coeff_a:%umV coeff_b:%umV\n", adc_chars.coeff_a, adc_chars.coeff_b);
+    } else {
+        Serial.printf("-->[BATT] ADC Default Vref: %u mV\n", vref);
+    }
+}
+
+
 void Battery_OLED::init(bool debug) {
+   this->debug = debug;
+    /*
+    ADC_EN is the ADC detection enable port
+    If the USB port is used for power supply, it is turned on by default.
+    If it is powered by battery, it needs to be set to high level
+    */
+    pinMode(ADC_EN, OUTPUT);
+    digitalWrite(ADC_EN, HIGH);
+    delay(10);                         // suggested by @ygator user in issue #2
+    setupBattADC();
+    delay(10);                         // suggested by @ygator user in issue #2
+
 }
 
 float Battery_OLED::getVoltage() {

--- a/lib/batterylib/battery_oled.hpp
+++ b/lib/batterylib/battery_oled.hpp
@@ -26,3 +26,12 @@ extern Battery_OLED battery;
 
 #endif
 
+void setupBattADC();
+void setupBattery();
+float battGetVoltage();
+uint8_t battCalcPercentage(float volts);
+void battUpdateChargeStatus();
+bool battIsCharging();
+void adcPowerOff();
+
+uint8_t _calcPercentage(float volts, float max, float min);

--- a/lib/batterylib/battery_oled.hpp
+++ b/lib/batterylib/battery_oled.hpp
@@ -4,9 +4,9 @@
 #include <battery.hpp>
 
 #define BATTERY_MIN_V 3.4
-#define BATTERY_MAX_V 4.1
-#define BATTCHARG_MIN_V 4.65
-#define BATTCHARG_MAX_V 4.8
+#define BATTERY_MAX_V 4.04
+#define BATTCHARG_MIN_V 3.69
+#define BATTCHARG_MAX_V 4.198
 #define ADC_PIN 34
 #define ADC_EN 14
 

--- a/lib/gui-utils-oled/src/GUIUtils.cpp
+++ b/lib/gui-utils-oled/src/GUIUtils.cpp
@@ -2,6 +2,8 @@
 
 #include "GUIIcons.h"
 
+#//include <battery.hpp>
+
 /******************************************************************************
 *   D I S P L A Y  M E T H O D S
 ******************************************************************************/
@@ -351,7 +353,8 @@ void GUIUtils::displayMainValues() {
 #endif
     u8g2.setFont(u8g2_font_6x12_tf);
 #ifndef TTGO_TQ
-    u8g2.setCursor(20, 39);
+    //u8g2.setCursor(20, 39);
+    u8g2.setCursor(2, 39);
 #else
 #ifdef EMOTICONS
     u8g2.setCursor(40, 23);  // valor RSSI
@@ -366,7 +369,20 @@ void GUIUtils::displayMainValues() {
         sprintf(output, "%02d", _rssi);
         u8g2.print(_rssi);
     }
+    if (_batteryCharge == 0) {
+        u8g2.print(" ");
+    } else {
+        u8g2.setFont(u8g2_font_6x12_tf);
+        u8g2.print(" ");
+        _batteryCharge = abs(_batteryCharge);
+        sprintf(output, "%02d", _batteryCharge);
+        u8g2.print(_batteryCharge);
+        u8g2.print("%");
+    }
     isNewData = false;
+
+
+
 }
 
 // TODO: separate this function, format/display
@@ -402,7 +418,12 @@ void GUIUtils::setInfoData(String info) {
 }
 
 void GUIUtils::setBatteryStatus(float volts, int charge, bool isCharging) {
-    // TODO:    
+    // TODO: 
+     suspendTaskGUI();
+    _batteryVolts = volts;
+    _batteryCharge = charge;
+    _isCharging = isCharging;
+    resumeTaskGUI();
 }
 
 void GUIUtils::displayGUIStatusFlags() {

--- a/lib/gui-utils-oled/src/GUIUtils.hpp
+++ b/lib/gui-utils-oled/src/GUIUtils.hpp
@@ -3,7 +3,6 @@
 
 #include <U8g2lib.h>
 //#include "hal.hpp"
-#include <Batterylib.hpp>
 
 enum AQI_COLOR { AQI_NONE, AQI_PM, AQI_CO2 };
 
@@ -134,6 +133,12 @@ class GUIUtils {
     bool _bleOn;
 
     bool _blePair;
+
+    float _batteryVolts;
+
+    int _batteryCharge;
+
+    bool _isCharging;
 
     bool isNewData;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,6 +227,12 @@ void setup() {
     
     WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); // Disable Brownout Detector 
 
+    if ( battery.getVoltage() < 3.3)
+    {
+        Serial.println("-->[Bat] Goto DeepSleep (curv to low)");
+        powerDeepSleepTimer(DEEP_SLEEP_TIME);
+    }
+
     // set cpu speed low to save battery
     setCpuFrequencyMhz(80);
     Serial.print("CPU Speed: ");


### PR DESCRIPTION
Solar Version. If Bat is <3.3 V, go to deep-sleep.
If no, the main board is in a continue loop, because has not enough power to do the wake up, and does reset continualy.