### PR TITLE
Solar station flag

### DIFF
--- a/lib/configlib/ConfigApp.cpp
+++ b/lib/configlib/ConfigApp.cpp
@@ -38,6 +38,7 @@ void ConfigApp::reload() {
     devmode = preferences.getBool("debugEnable", false);
     pax_enable = preferences.getBool("paxEnable", true);
     i2conly = preferences.getBool("i2conly", false);
+    solarmode = preferences.getBool("solarEnable", false);
     hassip = preferences.getString("hassip", "");
     hasspt = preferences.getInt("hasspt", 1883);
     hassusr = preferences.getString("hassusr", "");
@@ -62,8 +63,10 @@ String ConfigApp::getCurrentConfig() {
     doc["denb"] = preferences.getBool("debugEnable", false); // debug mode enable
     doc["penb"] = preferences.getBool("paxEnable", true);    // PaxCounter enable
     doc["i2conly"] = preferences.getBool("i2conly", false);  // force only i2c sensors
+    doc["solar"] = preferences.getBool("solarEnable", false);// Enable solar station
     doc["toffset"] = preferences.getFloat("toffset", 0.0);   // temperature offset
     doc["altoffset"] = preferences.getFloat("altoffset",0.0);// altitude offset
+    doc["sealevel"] = preferences.getFloat("sealevel",1013.25);// altitude offset
     doc["hassip"] = preferences.getString("hassip", "");     // Home Assistant MQTT server ip
     doc["hasspt"] = preferences.getInt("hasspt", 1883);      // Home Assistant MQTT server port
     doc["hassusr"] = preferences.getString("hassusr", "");   // Home Assistant MQTT user
@@ -194,8 +197,8 @@ bool ConfigApp::saveAltitudeOffset(float offset) {
     return true;
 }
 
-bool ConfigApp::saveSeaLevelPressure(float hpa) {
-    saveFloat("sealevelp", hpa);
+bool ConfigApp::saveSeaLevel(float hpa) {
+    saveFloat("sealevel", hpa);
     Serial.printf("-->[CONF] sea level pressure\t: %0.2f\n", hpa);
     if(mRemoteConfigCallBacks!=nullptr) this->mRemoteConfigCallBacks->onSeaLevelPressure(hpa);
     return true;
@@ -294,6 +297,13 @@ bool ConfigApp::paxEnable(bool enable) {
     return true;
 }
 
+bool ConfigApp::solarEnable(bool enable) {
+    saveBool("solarEnable", enable);
+    solarmode = enable;
+    Serial.println("-->[CONF] Solar Station mode\t: " + String(enable));
+    return true;
+}
+
 bool ConfigApp::saveI2COnly(bool enable) {
     saveBool("i2conly", enable);
     i2conly = enable;
@@ -366,6 +376,7 @@ bool ConfigApp::save(const char *json) {
     if (doc.containsKey("lat")) return saveGeo(doc["lat"].as<double>(), doc["lon"].as<double>(), doc["geo"] | "");
     if (doc.containsKey("toffset")) return saveTempOffset(doc["toffset"].as<float>());
     if (doc.containsKey("altoffset")) return saveAltitudeOffset(doc["altoffset"].as<float>());
+    if (doc.containsKey("sealevel")) return saveSeaLevel(doc["sealevel"].as<float>());
     if (doc.containsKey("hassip")) return saveHassIP(doc["hassip"] | "");
     if (doc.containsKey("hasspt")) return saveHassPort(doc["hasspt"] | 1883);
     if (doc.containsKey("hassusr")) return saveHassUser(doc["hassusr"] | "");
@@ -378,6 +389,7 @@ bool ConfigApp::save(const char *json) {
         if (act.equals("dst")) return debugEnable(doc["denb"].as<bool>());
         if (act.equals("i2c")) return saveI2COnly(doc["i2conly"].as<bool>());
         if (act.equals("pst")) return paxEnable(doc["penb"].as<bool>());
+        if (act.equals("sse")) return solarEnable(doc["sse"].as<bool>());
         if (act.equals("rbt")) reboot();
         if (act.equals("cls")) clear();
         if (act.equals("clb")) performCO2Calibration();

--- a/lib/configlib/ConfigApp.hpp
+++ b/lib/configlib/ConfigApp.hpp
@@ -83,6 +83,8 @@ class ConfigApp {
     bool debugEnable(bool enable);
     
     bool paxEnable(bool enable);
+    
+    bool solarEnable(bool enable);
 
     bool saveHassIP(String ip);
 
@@ -128,7 +130,7 @@ class ConfigApp {
 
     bool saveAltitudeOffset(float offset);
 
-    bool saveSeaLevelPressure(float hpa);
+    bool saveSeaLevel(float hpa);
 
     void setRemoteConfigCallbacks(RemoteConfigCallbacks* pCallbacks);
 
@@ -145,6 +147,8 @@ class ConfigApp {
     bool ifxdb_enable;
     /// PaxCounter on/off
     bool pax_enable = true;
+    /// PaxCounter on/off
+    bool solarmode = true;
     ///WiFi state
     bool wifi_connected;
 
@@ -182,6 +186,7 @@ class RemoteConfigCallbacks {
 public:
     virtual ~RemoteConfigCallbacks () {};
     virtual void onCO2Calibration();
+    virtual void onSolarEnable(bool enable);
     virtual void onAltitudeOffset(float altitude);
     virtual void onSeaLevelPressure(float hpa);
 };

--- a/lib/gui-utils-oled/src/GUIUtils.cpp
+++ b/lib/gui-utils-oled/src/GUIUtils.cpp
@@ -498,17 +498,6 @@ void GUIUtils::setCallbacks(GUIUserPreferencesCallbacks* pCallBacks){
 
 }
 
-uint8_t GUIUtils::getBatteryLevel(){
-    //float volts = battGetVoltage();
-    //float volts = getVoltage();
-    //return battCalcPercentage(volts); 
-}
-
-float GUIUtils::getBatteryVoltage(){
-    // return battGetVoltage();
-     //return getVoltage();
-}
-
 void GUIUtils::loop(){
     static uint_least64_t guiTimeStamp = 0;
     if (millis() - guiTimeStamp > 500) {

--- a/lib/gui-utils-oled/src/GUIUtils.hpp
+++ b/lib/gui-utils-oled/src/GUIUtils.hpp
@@ -85,10 +85,6 @@ class GUIUtils {
 
     String getFirmwareVersionCode ();
 
-    uint8_t getBatteryLevel();
-
-    float getBatteryVoltage();
-
     void loop();
 
    private:

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
 version = 0.5.1
-revision = 942
+revision = 898
 target = alpha
 monitor_filters = time
 extra_scripts = pre:prebuild.py
@@ -28,9 +28,27 @@ build_flags =
 lib_deps = 
 	bblanchon/ArduinoJson @ 6.19.1
 	chrisjoyce911/esp32FOTA @ 0.1.6
-    hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.3
+    ; hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.3
 	https://github.com/256dpi/arduino-mqtt.git
 	https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
+
+	adafruit/Adafruit Unified Sensor @ 1.1.4
+	adafruit/Adafruit BME280 Library @ 2.2.2
+	adafruit/Adafruit BMP280 Library @ 2.6.1
+	adafruit/Adafruit BME680 Library @ 2.0.1
+	adafruit/Adafruit BusIO @ 1.11.0
+	adafruit/Adafruit SHT31 Library @ 2.0.0
+	robtillaart/AM232X @ 0.4.0
+	enjoyneering/AHT10 @ 1.1.0
+	paulvha/sps30 @ 1.4.12
+	wifwaf/MH-Z19 @ 1.5.3
+	sparkfun/SparkFun SCD30 Arduino Library @ 1.0.17
+	sensirion/Sensirion Core @ 0.5.3
+	sensirion/Sensirion I2C SCD4x @ 0.3.1
+	https://github.com/hpsaturn/DHT_nonblocking.git
+	https://github.com/paulvha/SN-GCJA5.git
+	https://github.com/jcomas/S8_UART.git
+	https://github.com/jcomas/CM1106_UART.git
 
 [esp32_common]
 platform = espressif32

--- a/src/bluetooth.cpp
+++ b/src/bluetooth.cpp
@@ -90,7 +90,6 @@ class MyConfigCallbacks : public BLECharacteristicCallbacks {
                 }
                 if(sensors.toffset != cfg.toffset) sensors.setTempOffset(cfg.toffset);
                 if(sensors.devmode != cfg.devmode) sensors.setDebugMode(cfg.devmode);
-                if(sensors.sealevel != cfg.sealevel) sensors.setSeaLevelPressure(cfg.sealevel);
             }
             else{
                 Serial.println("[E][BTLE][CONFIG] saving error!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,6 +148,11 @@ class MyRemoteConfigCallBacks : public RemoteConfigCallbacks {
         Serial.println("-->[MAIN] onRemoteConfig new Sea Level Pressure");
         sensors.setSeaLevelPressure(hpa);
     }
+
+    void onSolarEnable(bool enable) {
+        Serial.println("-->[MAIN] onRemoteConfig Solar Mode");
+        sensors.solarmode = enable;
+    };
 };
 
 class MyBatteryUpdateCallbacks : public BatteryUpdateCallbacks {


### PR DESCRIPTION
## Overview

- [x] added initial flow of solarmode from config to sensors flag
- [x] added sealevel value from config to sensors
 
## Requeriments

Build with sensorslib on branch solar_station_flag

## Issues

### TTGO T-Display don't start

Output:

```
12:18:25.205 > == CanAirIO Setup ==
12:18:25.205 > 
12:18:25.205 > -->[Bat] Goto DeepSleep (curv to low)
12:18:36.906 > 
12:18:36.906 > == CanAirIO Setup ==
12:18:36.906 > 
12:18:36.906 > -->[Bat] Goto DeepSleep (curv to low)
12:18:38.772 > 
12:18:38.772 > == CanAirIO Setup ==
12:18:38.772 > 
12:18:38.772 > -->[Bat] Goto DeepSleep (curv to low)
``` 