### PR TITLE
Fix issue 218

### DIFF
--- a/lib/batterylib/battery_m5stack.hpp
+++ b/lib/batterylib/battery_m5stack.hpp
@@ -8,7 +8,7 @@
 
 #define BATTERY_MIN_V 3.4
 #define BATTERY_MAX_V 4.04
-#define BATTCHARG_MIN_V 3.69
+#define BATTCHARG_MIN_V 4.06
 #define BATTCHARG_MAX_V 4.198
 
 class Battery_M5STACK : public Battery {

--- a/lib/batterylib/battery_oled.hpp
+++ b/lib/batterylib/battery_oled.hpp
@@ -6,7 +6,7 @@
 
 #define BATTERY_MIN_V 3.4
 #define BATTERY_MAX_V 4.04
-#define BATTCHARG_MIN_V 3.69
+#define BATTCHARG_MIN_V 4.06
 #define BATTCHARG_MAX_V 4.198
 #define ADC_EN 14
 

--- a/lib/batterylib/battery_tft.hpp
+++ b/lib/batterylib/battery_tft.hpp
@@ -9,7 +9,7 @@
 
 #define BATTERY_MIN_V 3.4
 #define BATTERY_MAX_V 4.19
-#define BATTCHARG_MIN_V 4.21
+#define BATTCHARG_MIN_V 4.3
 #define BATTCHARG_MAX_V 4.8
 
 class Battery_TFT : public Battery {

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,9 +29,27 @@ build_flags =
   -D EMOTICONS  	            # enable emoticons on OLED version
 ; -D ENABLE_OTA                 # disable for memory saving, we have FOTA enable
 lib_deps = 
-	bblanchon/ArduinoJson @ 6.19.2
+	bblanchon/ArduinoJson @ 6.19.4
 	chrisjoyce911/esp32FOTA @ 0.1.6
-    hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.4
+    ; hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.4
+	adafruit/Adafruit Unified Sensor @ 1.1.5
+	adafruit/Adafruit BME280 Library @ 2.2.2
+	adafruit/Adafruit BMP280 Library @ 2.6.2
+	adafruit/Adafruit BME680 Library @ 2.0.2
+	adafruit/Adafruit BusIO @ 1.11.6
+	adafruit/Adafruit SHT31 Library @ 2.1.0
+	robtillaart/AM232X @ 0.4.1
+	enjoyneering/AHT10 @ 1.1.0
+	paulvha/sps30 @ 1.4.12
+	wifwaf/MH-Z19 @ 1.5.3
+	sparkfun/SparkFun SCD30 Arduino Library @ 1.0.17
+	sensirion/Sensirion Core @ 0.5.3
+	sensirion/Sensirion I2C SCD4x @ 0.3.1
+	https://github.com/hpsaturn/DHT_nonblocking.git
+	https://github.com/paulvha/SN-GCJA5.git
+	https://github.com/jcomas/S8_UART.git
+	https://github.com/jcomas/CM1106_UART.git
+
 	https://github.com/256dpi/arduino-mqtt.git
 	https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
 
@@ -82,7 +100,7 @@ board = esp32dev
 lib_ldf_mode = deep
 lib_deps = 
 	${common.lib_deps}
-	bodmer/TFT_eSPI @ 2.4.39
+	bodmer/TFT_eSPI @ 2.4.61
 lib_ignore = 
 	gui-utils-oled
 build_flags = 


### PR DESCRIPTION
## Description

This PR try to fix issue #218 but also it has some dependencies updates

- [x] Battery model levels on charge mode
- [x] Updated Sensorlib dependencies
- [ ] [Cash](https://github.com/kike-canaries/canairio_sensorlib/issues/136) with some I2C libraris (SCD30 and UGCJ5) with last Espressif framework 
- [ ] eTFT library warnnings