### PR TITLE
Fix axp192 m5 issue

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ lib_deps =
 	https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
 
 [esp32_common]
-platform = espressif32
+platform = ${common.platform}
 board = lolin32
 framework = ${common.framework}
 upload_speed = ${common.upload_speed}

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,8 +16,8 @@ platform = espressif32 @ 3.2.0
 framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
-version = 0.5.3
-revision = 908
+version = 0.5.4
+revision = 909
 target = dev
 monitor_filters = time
 extra_scripts = pre:prebuild.py
@@ -31,26 +31,7 @@ build_flags =
 lib_deps = 
 	bblanchon/ArduinoJson @ 6.19.4
 	chrisjoyce911/esp32FOTA @ 0.1.6
-    ; hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.5
-	adafruit/Adafruit Unified Sensor @ 1.1.5
-	adafruit/Adafruit BME280 Library @ 2.2.2
-	adafruit/Adafruit BMP280 Library @ 2.6.2
-	adafruit/Adafruit BME680 Library @ 2.0.2
-	adafruit/Adafruit SHT31 Library @ 2.1.0
-	adafruit/Adafruit SCD30 @ 1.0.8
-	adafruit/Adafruit BusIO @ 1.11.6
-	robtillaart/AM232X @ 0.4.1
-	enjoyneering/AHT10 @ 1.1.0
-	paulvha/sps30 @ 1.4.12
-	wifwaf/MH-Z19 @ 1.5.3
-	sensirion/Sensirion Core @ 0.5.3
-	sensirion/Sensirion I2C SCD4x @ 0.3.1
-	https://github.com/hpsaturn/DHT_nonblocking.git#ec6e5b9
-	https://github.com/paulvha/SN-GCJA5.git
-	https://github.com/jcomas/S8_UART.git
-	https://github.com/jcomas/CM1106_UART.git
-
-
+    hpsaturn/CanAirIO Air Quality Sensors Library @ 0.5.6
 	https://github.com/256dpi/arduino-mqtt.git
 	https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
 
@@ -155,4 +136,3 @@ lib_deps =
     build_flags = 
        ${common.build_flags}
        -D MAIN_HW_PIN=19
-	


### PR DESCRIPTION
## Description

- [x] fix issue with M5Devices on AXP192 calls (M5StickCPlus
- [x] updated Sensorslib to v0.5.6 (fixed some issues regarding that)


## Related Issues

#220 

## Tests

- [x] tested over M5Atom 
- [x] and M5StickCPlus  