### PR TITLE
Fixing bug in the lib_deps, hpsaturn/ESP32 Wifi CLI @ ^0.2.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ build_flags =
   ; -D ENABLE_OTA               # disable for memory saving, we have FOTA enable
 lib_deps = 
   bblanchon/ArduinoJson @ 6.21.2
-  hpsaturn/ESP32 Wifi CLI @ 0.2.1
+  hpsaturn/ESP32 Wifi CLI @ ^0.2.1
   https://github.com/chrisjoyce911/esp32FOTA.git#2bbc9cb
   https://github.com/rlogiacco/CircularBuffer.git#f29cf01
   https://github.com/256dpi/arduino-mqtt.git#7afcfb1


### PR DESCRIPTION
## Description

Fixing bug in the lib_deps, hpsaturn/ESP32 Wifi CLI @ ^0.2.1
Using the recommended notation, Accept new functionality in a backwards-compatible manner and patches

## Related Issues

With the recommended notation to include the library hpsaturn/ESP32 Wifi CLI, we don't have any errors when we try to build the project, the issue related to the picture:
![Screenshot-20240320171333-1302x111](https://github.com/kike-canaries/canairio_firmware/assets/695945/82a57636-0aea-45b9-a1a4-ae863db34420) 

