### PR TITLE
ArduinoJson migration - 6.x to 7.x

### DIFF
--- a/lib/ble/bluetooth.cpp
+++ b/lib/ble/bluetooth.cpp
@@ -14,7 +14,7 @@ bool oldDeviceConnected = false;
 *************************************************************************/
 
 String getNotificationData() {
-    StaticJsonDocument<40> doc;   // notification capacity is reduced, only main value
+    JsonDocument doc;   // notification capacity is reduced, only main value
     int deviceType = sensors.getUARTDeviceTypeSelected();
     if (deviceType <= 3) {
         doc["P25"] = sensors.getPM25();  
@@ -27,7 +27,7 @@ String getNotificationData() {
 }
 
 String getSensorData() {
-    StaticJsonDocument<512> doc;
+    JsonDocument doc;
     
     doc["P1"] = sensors.getPM1();
     doc["P25"] = sensors.getPM25();

--- a/lib/configlib/ConfigApp.cpp
+++ b/lib/configlib/ConfigApp.cpp
@@ -89,7 +89,7 @@ void reload() {
 }
 
 String getCurrentConfig() {
-    StaticJsonDocument<1000> doc;
+    JsonDocument doc;
     doc["wmac"] = (uint16_t)(chipid >> 32);  // chipid calculated in init
     doc["anaireid"] = getStationName();      // deviceId for Anaire cloud
     doc["wsta"] = wifi_connected;            // current wifi state
@@ -381,7 +381,7 @@ bool saveHassPassword(String passw) {
 }
 
 bool save(const char *json) {
-    StaticJsonDocument<1000> doc;
+    JsonDocument doc;
     auto error = deserializeJson(doc, json);
     if (error) {
         Serial.print(F("[E][CONF] deserialize Json failed with code "));
@@ -400,20 +400,20 @@ bool save(const char *json) {
     String act = doc["act"] | "";
 
     // if (doc.containsKey("dname")) return saveDeviceName(doc["dname"] | "");
-    if (doc.containsKey("stime")) return saveSampleTime(doc["stime"] | 0);
-    if (doc.containsKey("stype")) return saveSensorType(doc["stype"] | 0);
-    if (doc.containsKey("ifxdb")) return saveInfluxDb(doc["ifxdb"] | "", doc["ifxip"] | "", doc["ifxpt"] | 0);
-    if (doc.containsKey("pass") && doc.containsKey("ssid")) return saveWifi(doc["ssid"] | "", doc["pass"] | "");
-    if (doc.containsKey("ssid")) return saveSSID(doc["ssid"] | "");
-    if (doc.containsKey("lat")) return saveGeo(doc["lat"].as<double>(), doc["lon"].as<double>(), doc["geo"] | "");
-    if (doc.containsKey("toffset")) return saveTempOffset(doc["toffset"].as<float>());
-    if (doc.containsKey("altoffset")) return saveAltitudeOffset(doc["altoffset"].as<float>());
-    if (doc.containsKey("sealevel")) return saveSeaLevel(doc["sealevel"].as<float>());
-    if (doc.containsKey("hassip")) return saveHassIP(doc["hassip"] | "");
-    if (doc.containsKey("hasspt")) return saveHassPort(doc["hasspt"] | 1883);
-    if (doc.containsKey("hassusr")) return saveHassUser(doc["hassusr"] | "");
-    if (doc.containsKey("hasspsw")) return saveHassPassword(doc["hasspsw"] | "");
-    if (doc.containsKey("deepSleep")) return saveDeepSleep(doc["deepSleep"] | 0);
+    if (doc["stime"].is<int>()) return saveSampleTime(doc["stime"] | 0);
+    if (doc["stype"].is<int>()) return saveSensorType(doc["stype"] | 0);
+    if (doc["ifxdb"].is<int>()) return saveInfluxDb(doc["ifxdb"] | "", doc["ifxip"] | "", doc["ifxpt"] | 0);
+    if (doc["pass"].is<int>() && doc["ssid"].is<int>()) return saveWifi(doc["ssid"] | "", doc["pass"] | "");
+    if (doc["ssid"].is<int>()) return saveSSID(doc["ssid"] | "");
+    if (doc["lat"].is<int>()) return saveGeo(doc["lat"].as<double>(), doc["lon"].as<double>(), doc["geo"] | "");
+    if (doc["toffset"].is<int>()) return saveTempOffset(doc["toffset"].as<float>());
+    if (doc["altoffset"].is<int>()) return saveAltitudeOffset(doc["altoffset"].as<float>());
+    if (doc["sealevel"].is<int>()) return saveSeaLevel(doc["sealevel"].as<float>());
+    if (doc["hassip"].is<int>()) return saveHassIP(doc["hassip"] | "");
+    if (doc["hasspt"].is<int>()) return saveHassPort(doc["hasspt"] | 1883);
+    if (doc["hassusr"].is<int>()) return saveHassUser(doc["hassusr"] | "");
+    if (doc["hasspsw"].is<int>()) return saveHassPassword(doc["hasspsw"] | "");
+    if (doc["deepSleep"].is<int>()) return saveDeepSleep(doc["deepSleep"] | 0);
     
     // some actions with chopid validation (for security reasons)
     if (cmd == ((uint16_t)(chipid >> 32)) && act.length() > 0) {
@@ -434,18 +434,18 @@ bool save(const char *json) {
 }
 
 bool getTrackStatusValues(const char *json) {
-    StaticJsonDocument<200> doc;
+    JsonDocument doc;
     auto error = deserializeJson(doc, json);
     if (error) {
         Serial.print(F("[E][CONF] deserialize Json failed with code "));
         Serial.println(error.c_str());
         return false;
     }
-    if (doc.containsKey("spd")) track.spd = doc["spd"] | 0.0;
-    if (doc.containsKey("kms")) track.kms = doc["kms"] | 0.0;
-    if (doc.containsKey("hrs")) track.hrs = doc["hrs"] | 0;
-    if (doc.containsKey("min")) track.min = doc["min"] | 0;
-    if (doc.containsKey("seg")) track.seg = doc["seg"] | 0;
+    if (doc["spd"].is<int>()) track.spd = doc["spd"] | 0.0;
+    if (doc["kms"].is<int>()) track.kms = doc["kms"] | 0.0;
+    if (doc["hrs"].is<int>()) track.hrs = doc["hrs"] | 0;
+    if (doc["min"].is<int>()) track.min = doc["min"] | 0;
+    if (doc["seg"].is<int>()) track.seg = doc["seg"] | 0;
 
     return true;
 }

--- a/lib/wifi/cloud_anaire.cpp
+++ b/lib/wifi/cloud_anaire.cpp
@@ -20,7 +20,7 @@ void anairePublish() {
         float temp = sensors.getTemperature();
         if (temp == 0.0) temp = sensors.getCO2temp();
 
-        StaticJsonDocument<MQTT_BUFFER_SIZE> doc;
+        JsonDocument doc;
         char buffer[MQTT_BUFFER_SIZE];
 
         doc["id"] = getStationName();

--- a/lib/wifi/cloud_hass.cpp
+++ b/lib/wifi/cloud_hass.cpp
@@ -34,7 +34,7 @@ void hassPubSensorPayload() {
     float temp = sensors.getTemperature();
     if (temp == 0.0) temp = sensors.getCO2temp();
     
-    StaticJsonDocument<MQTT_BUFFER_SIZE> doc;
+    JsonDocument doc;
     char buffer[MQTT_BUFFER_SIZE];
 
     doc["carbon_dioxide"] = String(sensors.getCO2());
@@ -68,14 +68,14 @@ void hassPubSensorPayload() {
 }
 
 bool publishDiscoveryPayload(String name, String dclass, String unit) {
-    StaticJsonDocument<MQTT_BUFFER_SIZE> doc;
+    JsonDocument doc;
     doc["name"] = getHostId()+name; // name of the entity
-    JsonObject device = doc.createNestedObject("device");
+    JsonObject device = doc["device"].to<JsonObject>();
     device["manufacturer"] = "CanAirIO";
     device["model"] = ""+String(FLAVOR);
     device["name"] = getHostId();  // name of the device
     device["sw_version"] = "v"+String(VERSION)+" rev"+String(REVISION);
-    JsonArray identifiers = device.createNestedArray("identifiers");
+    JsonArray identifiers = device["identifiers"].to<JsonArray>();
     identifiers.add(getHostId()); // name of the device
     doc["state_topic"] = getStateTopic();
     doc["state_class"] = "measurement",

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ build_flags =
   ; -D DISABLE_CLI=1            # removed CLI module. Config via Bluetooth only
   ; -D ENABLE_OTA               # disable for memory saving. We have FOTA enable
 lib_deps = 
-  bblanchon/ArduinoJson @ 6.21.2
+  bblanchon/ArduinoJson @ 7.3.0
   hpsaturn/EasyPreferences @ 0.1.3
   ; hpsaturn/ESP32 Wifi CLI @ 0.3.1
   https://github.com/hpsaturn/esp32-wifi-cli.git#devel


### PR DESCRIPTION
- [x] ArduinoJson 6.x to 7x migration.
- [x] Tested on T-Display version.
- [x] BLE read test
- [x] LoRa version migration
- [x] MQTT test

MQTT config validation via CLI:

```bash
CanAirIO:$ klist
homeaEnable     custom          true 
anaireEnable    custom          false 
  ifxEnable     custom          true 
      ifxdb     custom          canairio 
      ifxip     custom          influxdb.canair.io 
      ifxpt     custom          8086 
     hassip     custom          192.168.178.145 
    hassusr     custom          canairio 
    hasspsw     custom          CanAirIO1234 
     hasspt     custom          1883 
```

MQTT PC broker test details:

```bash
mosquitto_sub -h localhost -p 1883 -t "homeassistant/sensor/CanAirIO85E/state" -u canairio -P CanAirIO1234
```

```json
{"carbon_dioxide":"0","humidity":"32.42","temperature":"24.11","pressure":"1030.85","altitude":"-145.51","gas":"819.62","pm1":"23","pm25":"26","pm4":"0","pm10":"29","signal_strength":"-67","battery":"90","voltage":"4.81","cpm":"0","usvh":"0.00","co":"0.00","nh3":"0.00","no2":"0.00"}
```
