### PR TITLE
Fix batt I2c block issue

### DIFF
--- a/lib/batterylib/battery.hpp
+++ b/lib/batterylib/battery.hpp
@@ -12,6 +12,11 @@ class BatteryUpdateCallbacks {
 #define FAST_RATE 500   // time into samples for catpure initial buffer
 #define SAMPLES 60      // # of samples on buffer (sample time = SAMPLES*FAST_RATE)
 
+#define BATT_MIN_V 3.4
+#define BATT_MAX_V 4.5
+#define BCHARG_MIN_V 3.8
+#define BCHARG_MAX_V 4.7
+
 class Battery {
  public:
   float curv = 0.0;

--- a/lib/batterylib/battery_m5stack.cpp
+++ b/lib/batterylib/battery_m5stack.cpp
@@ -5,7 +5,7 @@
 void Battery_M5STACK::init(bool debug) {
     this->debug = debug;
     // M5.Axp.EnableCoulombcounter();  // Enable Coulomb counter.
-    setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
+    // setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
 }
 
 float Battery_M5STACK::getVoltage() {

--- a/lib/batterylib/battery_oled.cpp
+++ b/lib/batterylib/battery_oled.cpp
@@ -50,7 +50,7 @@ void Battery_OLED::init(bool debug) {
   delay(10);  // suggested by @ygator user in issue #2
   setupBattADC();
   delay(10);  // suggested by @ygator user in issue #2
-  setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
+  // setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
 }
 
 float Battery_OLED::getVoltage() {

--- a/lib/batterylib/battery_oled.cpp
+++ b/lib/batterylib/battery_oled.cpp
@@ -43,8 +43,10 @@ void Battery_OLED::init(bool debug) {
     If the USB port is used for power supply, it is turned on by default.
     If it is powered by battery, it needs to be set to high level
     */
+  #ifndef TTGO_T7S3
   pinMode(ADC_EN, OUTPUT);
   digitalWrite(ADC_EN, HIGH);
+  #endif
   delay(10);  // suggested by @ygator user in issue #2
   setupBattADC();
   delay(10);  // suggested by @ygator user in issue #2

--- a/lib/batterylib/battery_oled.hpp
+++ b/lib/batterylib/battery_oled.hpp
@@ -4,19 +4,6 @@
 #include <battery.hpp>
 #include <esp_adc_cal.h>
 
-#if defined(TTGO_T7) || defined(TTGO_T7S3)
-#define BATTERY_MIN_V 3.4
-#define BATTERY_MAX_V 4.28
-#define BATTCHARG_MIN_V 3.8
-#define BATTCHARG_MAX_V 4.34
-#else
-
-#define BATTERY_MIN_V 3.1
-#define BATTERY_MAX_V 4.04
-#define BATTCHARG_MIN_V 4.06
-#define BATTCHARG_MAX_V 4.198
-#endif
-
 #define ADC_EN 14
 
 class Battery_OLED : public Battery {

--- a/lib/batterylib/battery_tft.cpp
+++ b/lib/batterylib/battery_tft.cpp
@@ -33,7 +33,7 @@ void Battery_TFT::init(bool debug) {
     delay(10);                         // suggested by @ygator user in issue #2
     setupBattADC();
     delay(10);                         // suggested by @ygator user in issue #2
-    setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
+    // setLimits(BATTERY_MIN_V, BATTERY_MAX_V, BATTCHARG_MIN_V, BATTCHARG_MAX_V);
 }
 
 float Battery_TFT::getVoltage () {

--- a/lib/gui-utils-oled/src/GUIUtils.cpp
+++ b/lib/gui-utils-oled/src/GUIUtils.cpp
@@ -28,7 +28,11 @@ void GUIUtils::displayInit(int ssd1306_type) {
       u8g2 = new U8G2_SSD1306_128X64_NONAME_F_HW_I2C(U8G2_R0, U8X8_PIN_NONE, U8X8_PIN_NONE, U8X8_PIN_NONE);
     }
 #endif
-    u8g2->setBusClock(100000);
+    if (FAMILY != "ESP32-S2") {
+      u8g2->setBusClock(100000);
+    } else {
+      u8g2->setBusClock(4000000);
+    }
     u8g2->begin();
     u8g2->setFont(u8g2_font_6x10_tf);
     u8g2->setContrast(128);

--- a/lib/gui-utils-oled/src/GUIUtils.cpp
+++ b/lib/gui-utils-oled/src/GUIUtils.cpp
@@ -28,7 +28,7 @@ void GUIUtils::displayInit(int ssd1306_type) {
       u8g2 = new U8G2_SSD1306_128X64_NONAME_F_HW_I2C(U8G2_R0, U8X8_PIN_NONE, U8X8_PIN_NONE, U8X8_PIN_NONE);
     }
 #endif
-    u8g2->setBusClock(4000000);
+    u8g2->setBusClock(100000);
     u8g2->begin();
     u8g2->setFont(u8g2_font_6x10_tf);
     u8g2->setContrast(128);

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -115,7 +115,7 @@ void powerLoop() {
   if ((millis() - powerTimeStamp > 30 * 1000)) {  // check it every 5 seconds
     powerTimeStamp = millis();
     float vbat = battery.getVoltage();
-    if (vbat > 3.0 && vbat < BATTERY_MIN_V) {
+    if (vbat > 3.0 && vbat < BATT_MIN_V) {
       Serial.println("-->[POWR] Goto DeepSleep (VBat too low)");
       if (solarmode)
         powerDeepSleepTimer(deepSleep);

--- a/lib/wifi/wifi.cpp
+++ b/lib/wifi/wifi.cpp
@@ -158,7 +158,8 @@ String getDeviceInfo() {
   info = info + "CPU: " + String(powerESP32TempRead()) + "°C\r\n";
   #endif
   #ifndef DISABLE_BATT
-  info = info + "BAT: " + String(battery.getVoltage()) + "v "+String(battery.getCharge()) +"%\r\n";
+  String charge = battery.isCharging() ? "charging" : "discharging";
+  info = info + "BAT: " + String(battery.getVoltage()) + "v "+String(battery.getCharge()) +"% ("+charge+")\r\n";
   #endif
   return info;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
   -D COMMANDER_MAX_COMMAND_SIZE=70
   -D WCLI_MAX_CMDS=16
   ; -D DISABLE_BLE=1            # removed Bluetooth module
-  ; -D DISABLE_BATT=1           # removed battery module
+  -D DISABLE_BATT=1           # removed battery module
   ; -D DISABLE_CLI_TELNET=1     # disable remote access via telnet. It needs CLI
   ; -D DISABLE_CLI=1            # removed CLI module. Config via Bluetooth only
   ; -D DISABLE_OLED=1           # removed OLED module (T7S3 has issues with it)
@@ -214,7 +214,7 @@ extends = esp32s3_common
 board_build.partitions = default_8MB.csv
 build_flags = 
   ${esp32s3_common.build_flags}
-  -D DISABLE_OLED=1              # removed OLED module (T7S3 has issues with it)
+  ; -D DISABLE_OLED=1              # removed OLED module (T7S3 has issues with it)
 
 ; experimental LoRa version
 [env:LORADEVKIT]

--- a/platformio.ini
+++ b/platformio.ini
@@ -174,7 +174,6 @@ extends = oled_common
 platform = espressif32 @ 6.9.0
 build_flags =
   ${oled_common.build_flags}
-  -D MAIN_HW_EN_PIN=3
   -D DISABLE_BLE=1
   -D DISABLE_BATT=1
 
@@ -184,6 +183,7 @@ board = lolin_s2_mini
 build_flags =
   ${esp32s2_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D MAIN_HW_EN_PIN=3
 
 [env:ESP32S2SAOLA]
 extends = esp32s2_common

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
   -D COMMANDER_MAX_COMMAND_SIZE=70
   -D WCLI_MAX_CMDS=16
   ; -D DISABLE_BLE=1            # removed Bluetooth module
-  -D DISABLE_BATT=1           # removed battery module
+  ; -D DISABLE_BATT=1           # removed battery module
   ; -D DISABLE_CLI_TELNET=1     # disable remote access via telnet. It needs CLI
   ; -D DISABLE_CLI=1            # removed CLI module. Config via Bluetooth only
   ; -D DISABLE_OLED=1           # removed OLED module (T7S3 has issues with it)
@@ -212,9 +212,6 @@ extends = esp32s3_common
 [env:TTGO_T7S3]
 extends = esp32s3_common
 board_build.partitions = default_8MB.csv
-build_flags = 
-  ${esp32s3_common.build_flags}
-  ; -D DISABLE_OLED=1              # removed OLED module (T7S3 has issues with it)
 
 ; experimental LoRa version
 [env:LORADEVKIT]

--- a/prebuild.py
+++ b/prebuild.py
@@ -32,7 +32,7 @@ target = config.get("common", "target")
 
 chipFamily = "ESP32"
 
-if flavor == "ESP32S2":
+if flavor == "ESP32S2" or flavor == "ESP32S2LOLIN":
     chipFamily = "ESP32-S2"
 
 if flavor == "ESP32C3" or flavor == "ESP32C3OIPLUS" or flavor == "ESP32C3LOLIN" or flavor == "ESP32C3SEEDX" or flavor == "AG_OPENAIR":

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,15 +270,15 @@ void initBattery() {
 }
 
 void initCLIFailsafe() {
+#ifndef DISABLE_CLI
   if (cfg.getBool(CONFKEYS::KFAILSAFE, true)) {
     delay(2000); // wait for new S3 and C3 CDC serial
     gui.welcomeAddMessage("wait for setup..");
     Serial.println("\n-->[INFO] == Type \"setup\" for enter in safe mode (over in 10seg!) ==");
-#ifndef DISABLE_CLI
     cliInit();
     logMemory("CLI ");
-#endif
   }
+#endif
 }
 
 void initCLI() {
@@ -305,10 +305,11 @@ void setup() {
     logMemory("INIT");
     // init app preferences and load settings
     init("canairio");
-    powerInit();
+    // powerInit();
     Serial.setDebugOutput(devmode);
     logMemory("CONF"); 
     // init graphic user interface
+    Wire.begin(13, 14);
     gui.setBrightness(getBrightness());
     gui.setWifiMode(isWifiEnable());
     gui.setPaxMode(isPaxEnable());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,11 +305,11 @@ void setup() {
     logMemory("INIT");
     // init app preferences and load settings
     init("canairio");
-    // powerInit();
+    powerInit();
     Serial.setDebugOutput(devmode);
     logMemory("CONF"); 
     // init graphic user interface
-    Wire.begin(13, 14);
+    sensors.startI2C(); // start I2C shared bus with OLED
     gui.setBrightness(getBrightness());
     gui.setWifiMode(isWifiEnable());
     gui.setPaxMode(isPaxEnable());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,18 +252,30 @@ void startingSensors() {
     delay(300);
 }
 
+#if defined(TTGO_T7) || defined(TTGO_T7S3)
+#define BATTERY_MIN_V 3.4
+#define BATTERY_MAX_V 4.28
+#define BATTCHARG_MIN_V 3.8
+#define BATTCHARG_MAX_V 4.34
+#else
+#define BATTERY_MIN_V 3.1
+#define BATTERY_MAX_V 4.04
+#define BATTCHARG_MIN_V 4.06
+#define BATTCHARG_MAX_V 4.198
+#endif
+
 void initBattery() {
 #ifndef DISABLE_BATT
   if (FAMILY != "ESP32-C3") {
     battery.setUpdateCallbacks(new MyBatteryUpdateCallbacks());
-    battery.init(devmode);
-    if (cfg.isKey(CONFKEYS::KBATVMX)) {
-      battery.setBattLimits(cfg.getFloat(CONFKEYS::KBATVMI), cfg.getFloat(CONFKEYS::KBATVMX));
-    }
-    if (cfg.isKey(CONFKEYS::KCHRVMX)) {
-      battery.setChargLimits(cfg.getFloat(CONFKEYS::KCHRVMI), cfg.getFloat(CONFKEYS::KCHRVMX));
-    }
+    battery.setBattLimits(
+      cfg.getFloat(CONFKEYS::KBATVMI, BATT_MIN_V),
+      cfg.getFloat(CONFKEYS::KBATVMX, BATT_MAX_V));
+    battery.setChargLimits(
+      cfg.getFloat(CONFKEYS::KCHRVMI, BCHARG_MIN_V),
+      cfg.getFloat(CONFKEYS::KCHRVMX, BCHARG_MAX_V));
     if (devmode) battery.printLimits();
+    battery.init(devmode);
     battery.update();
   }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 /**
  * @file main.cpp
  * @author Antonio Vanegas @hpsaturn
- * @date June 2018 - 2020
+ * @date June 2018 - 2025
  * @brief Particle meter sensor on ESP32 with bluetooth GATT notify server
  * @license GPL3
  */
@@ -321,7 +321,7 @@ void setup() {
     Serial.setDebugOutput(devmode);
     logMemory("CONF"); 
     // init graphic user interface
-    sensors.startI2C(); // start I2C shared bus with OLED
+    sensors.startI2C(); // I2C shared bus with OLED (ESP32S3 issue)
     gui.setBrightness(getBrightness());
     gui.setWifiMode(isWifiEnable());
     gui.setPaxMode(isPaxEnable());


### PR DESCRIPTION
## Description

Suspects: ADC pins or power library. They are disabled for now.

- [x] Added I2C init before OLED init
- [x] Skipped ADC_EN for T7S3
- [x] Tested on real hardware (boot)
- [x] Tested with battery 
- [x] Tested with ESP32, C3, S2 and S3 boards 

## Related Issues

#300 #296 #252