### PR TITLE
Fix issue 307

### DIFF
--- a/lib/cli/cli.cpp
+++ b/lib/cli/cli.cpp
@@ -207,6 +207,7 @@ void wcli_setup(char *args, Stream *response) {
   response->printf("UART sensor model \t: %s\r\n", sensors.getSensorName((SENSORS)stype).c_str());
   response->printf("UART sensor TX pin\t: %d\r\n", sTX == -1 ? PMS_TX : sTX);
   response->printf("UART sensor RX pin\t: %d\r\n", sRX == -1 ? PMS_RX : sRX);
+  response->printf("ENABLE HW sensor pin\t: %d\r\n", powerGetMainHwEnbPin());
   response->printf("Current debug mode\t: %s\r\n", devmode == true ? "enabled" : "disabled");
 
   wcli_klist((char *)"basic",response);

--- a/lib/cli/cli.hpp
+++ b/lib/cli/cli.hpp
@@ -8,6 +8,7 @@
 #endif
 #include "logmem.hpp"
 #include "Watchdog.hpp"
+#include "power.hpp"
 
 void cliInit();
 void cliTaskInit();

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -71,20 +71,37 @@ void powerLightSleepTimer(int seconds) {
     #endif
 }
 
+int powerGetMainHwEnbPin() {
+  int defaultHwEnPin = -1;
+#ifdef MAIN_HW_EN_PIN
+  defaultHwEnPin = MAIN_HW_EN_PIN;  // default pin for step-up enable
+#endif
+  int mainHwEnPin = cfg.getInt(CONFKEYS::KSENHWENB, defaultHwEnPin);
+  if (mainHwEnPin > 0 && mainHwEnPin < 40) {
+    return mainHwEnPin;  // return user configured pin
+  }
+  return defaultHwEnPin;
+}
+
 void powerEnableSensors() {
-    #ifdef MAIN_HW_EN_PIN
-    if(devmode) Serial.println("-->[POWR] == enable sensors ==");
+  int mainHwEnbPin = powerGetMainHwEnbPin();
+  if (mainHwEnbPin > 0) {
+    if (devmode) Serial.println("-->[POWR] == enable sensors ==");
+    if (devmode) Serial.println("-->[POWR] Sensors enable pin\t: " + String(mainHwEnbPin));
     // init all sensors (step-up to 5V with enable pin)
-    pinMode(MAIN_HW_EN_PIN, OUTPUT);
-    digitalWrite(MAIN_HW_EN_PIN, HIGH);  // step-up on
-    #endif
+    pinMode(mainHwEnbPin, OUTPUT);
+    digitalWrite(mainHwEnbPin, HIGH);  // step-up on
+  }
+  else
+    log_i("[POWR] No sensors enable pin configured, Skipping..");
 }
 
 void powerDisableSensors() {
-    #ifdef MAIN_HW_EN_PIN
+  int mainHwEnbPin = powerGetMainHwEnbPin();
+  if (mainHwEnbPin > 0) {
     if(devmode) Serial.println("-->[POWR] == disable sensors ==");
-    digitalWrite(MAIN_HW_EN_PIN, LOW);  // step-up off
-    #endif
+    digitalWrite(mainHwEnbPin, LOW);  // step-up off
+  }
 }
 
 void powerTempSensorInit() {

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -72,15 +72,19 @@ void powerLightSleepTimer(int seconds) {
 }
 
 void powerEnableSensors() {
+    #ifdef MAIN_HW_EN_PIN
     if(devmode) Serial.println("-->[POWR] == enable sensors ==");
     // init all sensors (step-up to 5V with enable pin)
     pinMode(MAIN_HW_EN_PIN, OUTPUT);
     digitalWrite(MAIN_HW_EN_PIN, HIGH);  // step-up on
+    #endif
 }
 
 void powerDisableSensors() {
+    #ifdef MAIN_HW_EN_PIN
     if(devmode) Serial.println("-->[POWR] == disable sensors ==");
     digitalWrite(MAIN_HW_EN_PIN, LOW);  // step-up off
+    #endif
 }
 
 void powerTempSensorInit() {

--- a/lib/power/power.hpp
+++ b/lib/power/power.hpp
@@ -10,12 +10,16 @@
 #include <esp_wifi.h>
 
 
-float powerESP32TempRead();
+
 void powerCompleteShutdown();
 void powerDeepSleepButton();
 void powerDeepSleepTimer(int);
 void powerLightSleepTimer(int);
 void powerEnableSensors();
 void powerDisableSensors();
+
+float powerESP32TempRead();
+int powerGetMainHwEnbPin();
+
 void powerLoop();
 void powerInit();

--- a/lib/preferences/preferences-keys.h
+++ b/lib/preferences/preferences-keys.h
@@ -34,5 +34,6 @@
   X(KSOLAREN, "solarEnable", BOOL)  \
   X(KDEEPSLP, "deepSleep", INT)     \
   X(KGEIGERP, "geigerPin", INT)     \
+  X(KSENHWENB, "sensorsENPin", INT)     \
   X(KFTXPWR, "forceTxPower", BOOL)  \
   X(KCOUNT, "KCOUNT", UNKNOWN)

--- a/lib/watchdoglib/Watchdog.cpp
+++ b/lib/watchdoglib/Watchdog.cpp
@@ -30,17 +30,11 @@ void Watchdog::loop() {
 
 void IRAM_ATTR resetModule() {
   Serial.println("-->[WDOG] Watchdog reached, rebooting..");
-  #ifdef MAIN_HW_EN_PIN
-  digitalWrite(MAIN_HW_EN_PIN, LOW);
-  #endif
   esp_wifi_disconnect();
   delay(200);
   esp_wifi_stop();
   delay(200);
   esp_wifi_deinit();
-  #ifdef MAIN_HW_EN_PIN
-  digitalWrite(MAIN_HW_EN_PIN, HIGH);
-  #endif
   delay(200);
   ESP.restart();
 }

--- a/lib/watchdoglib/Watchdog.cpp
+++ b/lib/watchdoglib/Watchdog.cpp
@@ -30,13 +30,17 @@ void Watchdog::loop() {
 
 void IRAM_ATTR resetModule() {
   Serial.println("-->[WDOG] Watchdog reached, rebooting..");
+  #ifdef MAIN_HW_EN_PIN
   digitalWrite(MAIN_HW_EN_PIN, LOW);
+  #endif
   esp_wifi_disconnect();
   delay(200);
   esp_wifi_stop();
   delay(200);
   esp_wifi_deinit();
+  #ifdef MAIN_HW_EN_PIN
   digitalWrite(MAIN_HW_EN_PIN, HIGH);
+  #endif
   delay(200);
   ESP.restart();
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ board = lolin32
 board_build.partitions = min_spiffs.csv
 build_flags = 
   ${common.build_flags}
-  -D MAIN_HW_EN_PIN=27
+  ; -D MAIN_HW_EN_PIN=27
 
 [oled_common]
 extends = esp32_common
@@ -112,7 +112,7 @@ lib_deps =
 extends = oled_common
 build_flags = 
   ${esp32_common.build_flags}
-  -D MAIN_HW_EN_PIN=19
+  ; -D MAIN_HW_EN_PIN=19
 
 [tft_common]
 extends = esp32_common
@@ -135,6 +135,7 @@ lib_deps =
 build_flags = 
   ${esp32_common.build_flags}
   -D USER_SETUP_LOADED=1
+  -D MAIN_HW_EN_PIN=27
   -include .pio/libdeps/${PIOENV}/TFT_eSPI/User_Setups/Setup25_TTGO_T_Display.h
 
 [esp32c3_common]
@@ -143,7 +144,7 @@ extends = oled_common
 board = esp32-c3-devkitm-1
 build_flags =
   ${oled_common.build_flags}
-  -D MAIN_HW_EN_PIN=3         # enable the main hardware pin (optional)
+  ; -D MAIN_HW_EN_PIN=3         # enable the main hardware pin (optional)
   -D DISABLE_BATT=1           # removed battery module (ADC is not working) 
   -D DISABLE_SNIFFER=1        # removed sniffer module (for 4Mb flash boards)
   -D DISABLE_CLI_TELNET=1     # disable telnet festure (for 4Mb flash boards) 
@@ -188,7 +189,7 @@ board = lolin_s2_mini
 build_flags =
   ${esp32s2_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
-  -D MAIN_HW_EN_PIN=3
+  ; -D MAIN_HW_EN_PIN=3
 
 [env:ESP32S2SAOLA]
 extends = esp32s2_common
@@ -209,7 +210,7 @@ build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D BOARD_HAS_PSRAM=1
   ; -mfix-esp32-psram-cache-issue
-  -D MAIN_HW_EN_PIN=3          # enable the main hardware pin (main sensor)
+  ; -D MAIN_HW_EN_PIN=3          # enable the main hardware pin (main sensor)
 
 [env:ESP32S3]  
 extends = esp32s3_common
@@ -217,7 +218,7 @@ board_build.arduino.memory_type = dio_opi ;
 board_build.partitions = default_8MB.csv
 build_flags = 
   ${common.build_flags}
-  -D MAIN_HW_EN_PIN=21          # enable the main hardware pin (main sensor)
+  ; -D MAIN_HW_EN_PIN=21          # enable the main hardware pin (main sensor)
 
 [env:TTGO_T7S3]
 extends = esp32s3_common

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,6 @@ board = lolin32
 board_build.partitions = min_spiffs.csv
 build_flags = 
   ${common.build_flags}
-  ; -D MAIN_HW_EN_PIN=27
 
 [oled_common]
 extends = esp32_common

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -349,9 +349,6 @@ void setup() {
     // Sensors library initialization
     Serial.println("-->[INFO] == Detecting Sensors ==");
     Serial.println("-->[INFO] Sensorslib version\t: " + sensors.getLibraryVersion());
-    #ifdef MAIN_HW_EN_PIN
-    Serial.println("-->[INFO] enable hw on GPIO\t: " + String(MAIN_HW_EN_PIN));
-    #endif
     startingSensors();
     logMemory("SLIB");
     // Setting callback for remote commands via Bluetooth config

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -349,7 +349,9 @@ void setup() {
     // Sensors library initialization
     Serial.println("-->[INFO] == Detecting Sensors ==");
     Serial.println("-->[INFO] Sensorslib version\t: " + sensors.getLibraryVersion());
+    #ifdef MAIN_HW_EN_PIN
     Serial.println("-->[INFO] enable hw on GPIO\t: " + String(MAIN_HW_EN_PIN));
+    #endif
     startingSensors();
     logMemory("SLIB");
     // Setting callback for remote commands via Bluetooth config


### PR DESCRIPTION
## Description

Now with this PR the only board that has the MAIN_HW_PIN is the TTGO-TDisplay. This optional pin could set via CLI and the **kset** command using the variable **sensorsENPin**

```shell
kset sensorsENPin 3
```
## ISSUES

#307 

## TODO

- [x] removed all Pio manifest definitions (TDisplay is the only exception)
- [x] CLI implementation via kset
- [x] show in setup 
