### PR TITLE
Disable BLE module on OpenAir esp32c3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -179,6 +179,9 @@ build_flags =
   ${esp32c3_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D ARDUINO_USB_MODE=1
+  -D DISABLE_BATT=1
+  -D DISABLE_BLE=1
+  -D DISABLE_SNIFFER=1
 
 [esp32s2_common]
 extends = oled_common


### PR DESCRIPTION

## Summary

Seems that the last BLE module implementation is failing in the OpenAir ESP32C3 Module. Issue #334  