### PR TITLE
c3 s3 BLE parche

### DIFF
--- a/lib/ble/bluetooth.cpp
+++ b/lib/ble/bluetooth.cpp
@@ -6,12 +6,66 @@
 #include <bluetooth.hpp>
 #include <sniffer.h>
 
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include <string>
+
 BLEServer* pServer = NULL;
 BLECharacteristic* pCharactData = NULL;
 BLECharacteristic* pCharactConfig = NULL;
 BLECharacteristic* pCharactStatus = NULL;
 bool deviceConnected = false;
 bool oldDeviceConnected = false;
+
+/*************************************************************************
+*   T H R E A D   S A F E T Y   N O T E S
+*
+*  All BLECharacteristicCallbacks / BLEServerCallbacks run on the Bluedroid
+*  BTC task, NOT on the Arduino loop task. On the Arduino core that task has
+*  only CONFIG_BT_BTC_TASK_STACK_SIZE = 3072 bytes of stack.
+*
+*  Two consequences, both of them sources of crashes in the past:
+*
+*  1) Heavy work (ArduinoJson, NVS/Preferences, GUI drawing, verbose logging)
+*     must NOT run inside the callbacks: it overflows the BTC stack, which
+*     shows up as an unrelated assert (xQueueGenericSend, queue.c) instead of
+*     a clean stack overflow message. Callbacks below only copy the payload
+*     and raise a flag; bleLoop() does the real work on the loop task.
+*
+*  2) The characteristic value is touched from both tasks, so every
+*     setValue()/getValue() goes through the bleMtx mutex.
+*
+*  Related issues: #302 #303 #337
+*************************************************************************/
+
+static SemaphoreHandle_t bleMtx = NULL;        // guards characteristic values
+static SemaphoreHandle_t blePendingMtx = NULL; // guards the deferred buffers
+
+// deferred work, filled from the BTC task, consumed by the Arduino loop task
+static volatile bool pendingConfigRead = false;
+static volatile bool pendingConfigWrite = false;
+static volatile bool pendingStatusWrite = false;
+static std::string pendingConfigPayload;
+static std::string pendingStatusPayload;
+
+static void safeSetValue(BLECharacteristic* pCharact, const String& value) {
+    if (bleMtx != NULL && xSemaphoreTake(bleMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+        pCharact->setValue(value.c_str());
+        xSemaphoreGive(bleMtx);
+    } else {
+        log_w("[BTLE] safeSetValue: mutex timeout, value not updated");
+    }
+}
+
+static std::string safeGetValue(BLECharacteristic* pCharact) {
+    std::string value;
+    if (bleMtx != NULL && xSemaphoreTake(bleMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+        value = pCharact->getValue();
+        xSemaphoreGive(bleMtx);
+    }
+    return value;
+}
 
 /*************************************************************************
 *   B L U E T O O T H   P A Y L O A D
@@ -58,57 +112,52 @@ String getSensorData() {
 }
 
 /*************************************************************************
-*   B L U E T O O T H   M E T H O D S
+*   B L U E T O O T H   M E T H O D S   (loop task only)
 *************************************************************************/
 
 void bleServerDataRefresh(){
-    pCharactData->setValue(getSensorData().c_str());
+    safeSetValue(pCharactData, getSensorData());
 }
 
+// WARNING: builds the config JSON (ArduinoJson + ~25 NVS reads). Call it only
+// from the Arduino loop task, never from a BLE callback.
 void bleServerConfigRefresh(){
     setWifiConnected(WiFi.isConnected());  // for notify on each write
-    pCharactConfig->setValue(getCurrentConfig().c_str());
-    delay(100);
+    safeSetValue(pCharactConfig, getCurrentConfig());
 }
+
+/*************************************************************************
+*   B L E   C A L L B A C K S   (BTC task: keep them minimal)
+*************************************************************************/
 
 // Config BLE callbacks
 class MyConfigCallbacks : public BLECharacteristicCallbacks {
     void onWrite(BLECharacteristic* pCharacteristic) {
-        std::string value = pCharacteristic->getValue();
-        if (value.length() > 0) {
-            if (save(value.c_str())) {
-                gui.displayPreferenceSaveIcon();
-                gui.setWifiMode(isWifiEnable());
-
-                if(sensors.sample_time != stime) {
-                    sensors.setSampleTime(stime);
-                    gui.setSampleTime(stime);
-                }
-                if(sensors.toffset != toffset) sensors.setTempOffset(toffset);
-                if(sensors.devmode != devmode) sensors.setDebugMode(devmode);
-            }
-            else{
-                log_w("[W][BTLE][CONFIG] save return false with %s",value.c_str());
-            }
+        std::string value = safeGetValue(pCharacteristic);
+        if (value.length() == 0) return;
+        if (blePendingMtx != NULL && xSemaphoreTake(blePendingMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+            pendingConfigPayload = value;   // deferred: save() runs on the loop task
+            pendingConfigWrite = true;
+            xSemaphoreGive(blePendingMtx);
         }
     };
 
     void onRead(BLECharacteristic* pCharacteristic) {
-        bleServerConfigRefresh();
+        // deferred: the value was already refreshed by bleLoop(), just ask for
+        // a new refresh after answering this read.
+        pendingConfigRead = true;
     }
 };
 
 // Status BLE callbacks
 class MyStatusCallbacks : public BLECharacteristicCallbacks {
     void onWrite(BLECharacteristic* pCharacteristic) {
-        std::string value = pCharacteristic->getValue();
-        if (value.length() > 0 && getTrackStatusValues(value.c_str())) {
-            log_v("[E][BTLE][STATUS] %s", value.c_str());
-            gui.setTrackValues(track.spd,track.kms);
-            gui.setTrackTime(track.hrs,track.min,track.seg);
-        }
-        else {
-            Serial.println("[E][BTLE][STATUS] write error!");
+        std::string value = safeGetValue(pCharacteristic);
+        if (value.length() == 0) return;
+        if (blePendingMtx != NULL && xSemaphoreTake(blePendingMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+            pendingStatusPayload = value;   // deferred: GUI update on the loop task
+            pendingStatusWrite = true;
+            xSemaphoreGive(blePendingMtx);
         }
     }
 };
@@ -116,6 +165,7 @@ class MyStatusCallbacks : public BLECharacteristicCallbacks {
 class MyServerCallbacks : public BLEServerCallbacks {
     void onConnect(BLEServer* pServer) {
         deviceConnected = true;
+        pendingConfigRead = true;  // refresh config for the incoming client
         Serial.println("-->[BTLE] device client is connected.");
     };
 
@@ -125,9 +175,68 @@ class MyServerCallbacks : public BLEServerCallbacks {
     };
 };  // BLEServerCallbacks
 
+/*************************************************************************
+*   D E F E R R E D   W O R K   (loop task)
+*************************************************************************/
 
+static void bleProcessPendingWork() {
+    if (pendingConfigWrite) {
+        std::string payload;
+        if (blePendingMtx != NULL && xSemaphoreTake(blePendingMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+            payload = pendingConfigPayload;
+            pendingConfigWrite = false;
+            xSemaphoreGive(blePendingMtx);
+        }
+        if (payload.length() > 0) {
+            if (save(payload.c_str())) {
+                gui.displayPreferenceSaveIcon();
+                gui.setWifiMode(isWifiEnable());
+
+                if (sensors.sample_time != stime) {
+                    sensors.setSampleTime(stime);
+                    gui.setSampleTime(stime);
+                }
+                if (sensors.toffset != toffset) sensors.setTempOffset(toffset);
+                if (sensors.devmode != devmode) sensors.setDebugMode(devmode);
+            } else {
+                log_w("[W][BTLE][CONFIG] save return false with %s", payload.c_str());
+            }
+            pendingConfigRead = true;  // publish the updated config
+        }
+    }
+
+    if (pendingStatusWrite) {
+        std::string payload;
+        if (blePendingMtx != NULL && xSemaphoreTake(blePendingMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+            payload = pendingStatusPayload;
+            pendingStatusWrite = false;
+            xSemaphoreGive(blePendingMtx);
+        }
+        if (payload.length() > 0) {
+            if (getTrackStatusValues(payload.c_str())) {
+                log_v("[BTLE][STATUS] %s", payload.c_str());
+                gui.setTrackValues(track.spd, track.kms);
+                gui.setTrackTime(track.hrs, track.min, track.seg);
+            } else {
+                Serial.println("[E][BTLE][STATUS] write error!");
+            }
+        }
+    }
+
+    if (pendingConfigRead) {
+        pendingConfigRead = false;
+        bleServerConfigRefresh();
+    }
+}
+
+/*************************************************************************
+*   S E R V E R   I N I T   /   L O O P
+*************************************************************************/
 
 void bleServerInit() {
+    // Create the mutexes before any setValue() call
+    if (bleMtx == NULL) bleMtx = xSemaphoreCreateMutex();
+    if (blePendingMtx == NULL) blePendingMtx = xSemaphoreCreateMutex();
     // Create the BLE Device
     BLEDevice::init("CanAirIO_ESP32");
     // Create the BLE Server
@@ -165,13 +274,19 @@ void bleServerInit() {
 
 void bleLoop() {
     static uint_fast64_t bleTimeStamp = 0;
+    // deferred work coming from the BLE callbacks (runs on this task)
+    bleProcessPendingWork();
     // notify changed value
     if (deviceConnected && (millis() - bleTimeStamp > stime * 1000)) {  // each 5 secs
         log_i("[BTLE] sending notification..");
-        log_d("[BTLE] %s",getNotificationData().c_str());
         bleTimeStamp = millis();
-        pCharactData->setValue(getNotificationData().c_str());  // small payload for notification
-        pCharactData->notify();
+        String payload = getNotificationData();  // small payload for notification
+        log_d("[BTLE] %s", payload.c_str());
+        if (bleMtx != NULL && xSemaphoreTake(bleMtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+            pCharactData->setValue(payload.c_str());
+            pCharactData->notify();
+            xSemaphoreGive(bleMtx);
+        }
         bleServerDataRefresh();
     }
     // disconnecting

--- a/lib/configlib/ConfigApp.cpp
+++ b/lib/configlib/ConfigApp.cpp
@@ -108,9 +108,12 @@ String getCurrentConfig() {
     String output;
     serializeJson(doc, output);
 #if CORE_DEBUG_LEVEL >= 3
-    char buf[1000];
-    serializeJsonPretty(doc, buf, 1000);
-    Serial.printf("-->[CONF] respons@e: %s\r\n", buf);
+    // NOTE: this runs on the Bluedroid BTC task (3072 bytes of stack) when the
+    // BLE client reads the config characteristic. A 1000 bytes stack buffer
+    // here overflows that stack. Stream straight to Serial instead (no buffer).
+    Serial.print("-->[CONF] response: ");
+    serializeJsonPretty(doc, Serial);
+    Serial.println();
 #endif
     on_read_config = false;
     return output;
@@ -381,9 +384,11 @@ bool save(const char *json) {
     }
 
 #if CORE_DEBUG_LEVEL >= 3
-    char output[1000];
-    serializeJsonPretty(doc, output, 1000);
-    Serial.printf("-->[CONF] request: %s\r\n", output);
+    // NOTE: same as in getCurrentConfig(), save() is reached from the BLE
+    // write callback, which runs on the BTC task. No big stack buffers here.
+    Serial.print("-->[CONF] request: ");
+    serializeJsonPretty(doc, Serial);
+    Serial.println();
 #endif
 
     uint16_t cmd = doc["cmd"].as<uint16_t>();

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ revision = 990
 target = dev
 
 [env]
-build_type = release
+build_type = debug
 platform = espressif32 @ 4.4.0
 framework = arduino
 upload_speed = 1500000
@@ -30,7 +30,7 @@ monitor_filters =
   ; time
 extra_scripts = pre:prebuild.py
 build_flags = 
-  -D CORE_DEBUG_LEVEL=0         # For debugging set to 3 and enable debug mode in the app
+  -D CORE_DEBUG_LEVEL=4         # For debugging set to 3 and enable debug mode in the app
   -D MIN_PUBLISH_INTERVAL=30    # Minimum interval between clouds updates
   -D WAIT_FOR_PM_SENSOR=25      # time of stabilization of PM sensors in seconds
   -D ARDUINO_ESP32_DEV=1        # compatibilty for DFRobot NH3/CO library

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ revision = 990
 target = dev
 
 [env]
-build_type = debug
+build_type = release
 platform = espressif32 @ 4.4.0
 framework = arduino
 upload_speed = 1500000
@@ -30,7 +30,7 @@ monitor_filters =
   ; time
 extra_scripts = pre:prebuild.py
 build_flags = 
-  -D CORE_DEBUG_LEVEL=4         # For debugging set to 3 and enable debug mode in the app
+  -D CORE_DEBUG_LEVEL=0         # For debugging set to 3 and enable debug mode in the app
   -D MIN_PUBLISH_INTERVAL=30    # Minimum interval between clouds updates
   -D WAIT_FOR_PM_SENSOR=25      # time of stabilization of PM sensors in seconds
   -D ARDUINO_ESP32_DEV=1        # compatibilty for DFRobot NH3/CO library


### PR DESCRIPTION
[Los cambios sobre el original:
Mutex bleMtx (FreeRTOS) creado al principio de bleServerInit(), con dos helpers safeSetValue() / safeGetValue() que serializan todo acceso al valor de las características entre el loop de Arduino y el hilo BTC de Bluedroid. Timeout de 50 ms — en el peor caso se responde con el valor anterior en vez de bloquear el stack.
delay(100) eliminado de bleServerConfigRefresh() — esa función corre también en el hilo BT vía onRead, y además la llama main.cpp desde el callback de config (otra tarea más: tercera vía de entrada a la misma variable, lo que confirma que el mutex era necesario).
En bleLoop(), el payload JSON se construye fuera de la sección crítica (una sola vez, reutilizado para el log_d — de paso se ahorra la doble serialización que hacía el original) y el par setValue + notify va junto dentro del mutex.
Los getValue() de los onWrite (config y status) también pasan por el helper — la copia del valor escrito podía chocar igualmente con un setValue del loop.
Comentario en cabecera del mutex referenciando los issues #302/#303/#337