### PR TITLE
sdkconfig rules for thin firmware - experimental

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ releases/manifest
 releases/wokwi
 releases/installer/rev*
 lib/easy-preferences
+sdkconfig.*
 # IDE
 .travis.yml
 extensions.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Requerido por PlatformIO cuando framework = arduino, espidf
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(canairio_firmware)

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 ################################################################
 # CanAirIO Deploy Util
 # ====================
@@ -82,17 +82,13 @@ build () {
   FIRMDIR=$RELDIR/$BINDIR/$1
   mkdir -p $FIRMDIR 
   cp $OUTDIR/$1/firmware.bin $FIRMDIR/${NAME}_${1}_rev${SRC_REV}.bin
-  pio pkg exec -p "tool-esptoolpy@1.40501.0" -- esptool.py version
+  python3 ${PIO_HOME}/packages/tool-esptoolpy/esptool.py version
   if [ $1 == ESP32C3 ] || [ $1 == ESP32C3LOLIN ] || [ $1 == ESP32C3SEEDX ] || [ $1 == ESP32C3OIPLUS ]; then
-    pio pkg exec -p "tool-esptoolpy@1.40501.0" -- esptool.py --chip esp32c3 merge_bin -o  $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 $OUTDIR/$1/bootloader.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 ${PIO_HOME}/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
+    python3 ${PIO_HOME}/packages/tool-esptoolpy/esptool.py --chip esp32c3 merge_bin -o  $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 $OUTDIR/$1/bootloader.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 ${PIO_HOME}/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
   elif [ $1 == ESP32S3 ] || [ $1 == TTGO_T7S3 ]; then
-    pio pkg exec -p "tool-esptoolpy@1.40501.0" -- esptool.py --chip esp32s3 merge_bin -o  $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0000 $OUTDIR/$1/bootloader.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 ${PIO_HOME}/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
+    python3 ${PIO_HOME}/packages/tool-esptoolpy/esptool.py --chip esp32s3 merge_bin -o  $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0000 $OUTDIR/$1/bootloader.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 ${PIO_HOME}/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
   else
-    find $PIO_HOME -wholename "*esp32/*bootloader_dio_40m.bin" -exec cp {} $FIRMDIR/ ";"
-    find $PIO_HOME -wholename "*espressif32/*boot_app0.bin" -exec cp {} $FIRMDIR/ ";"
-    if [ ! -e $FIRMDIR/boot_app0.bin ]; then echo "error: !file not found! ==> boot_app0.bin"; fi
-    if [ ! -e $FIRMDIR/bootloader_dio_40m.bin ]; then echo "error: !file not found! ==> bootloader_dio_40m.bin"; fi
-    pio pkg exec -p "tool-esptoolpy@1.40501.0" -- esptool.py --chip esp32 merge_bin -o $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 40m --flash_size 4MB 0x1000 $FIRMDIR/bootloader_dio_40m.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 $FIRMDIR/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
+    python3 ${PIO_HOME}/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin --flash_mode dio --flash_freq 40m --flash_size 4MB 0x1000 $OUTDIR/$1/bootloader.bin 0x8000 $OUTDIR/$1/partitions.bin 0xe000 ${PIO_HOME}/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 $OUTDIR/$1/firmware.bin
   fi
   md5sum $FIRMDIR/${NAME}_${1}_rev${SRC_REV}_merged.bin
   md5sum $FIRMDIR/${NAME}_${1}_rev${SRC_REV}.bin
@@ -241,6 +237,7 @@ else
         echo ""
         echo "Please check flavor parameter with 'list' command"
         echo ""
+        exit 1
       fi
       ;;
   esac

--- a/canairio_ota_4mb.csv
+++ b/canairio_ota_4mb.csv
@@ -1,7 +1,0 @@
-# Name,   Type, SubType, Offset,   Size,     Flags
-nvs,      data, nvs,     0x9000,   0x5000,
-otadata,  data, ota,     0xe000,   0x2000,
-app0,     app,  ota_0,   0x10000,  0x1E0000,
-app1,     app,  ota_1,   0x1F0000, 0x1E0000,
-spiffs,   data, spiffs,  0x3D0000, 0x20000,
-coredump, data, coredump,0x3F0000, 0x10000,

--- a/lib/logmem/logmem.cpp
+++ b/lib/logmem/logmem.cpp
@@ -5,7 +5,7 @@
 uint32_t heap_size = 0;
 
 void checkCoreDumpPartition() {
-  #if (defined ESP32S3 || defined ESP32C3)
+  #if (defined DEBUG_MODE_NO_IDF_RULES)
   esp_core_dump_init();
   esp_core_dump_summary_t *summary =
       static_cast<esp_core_dump_summary_t *>(malloc(sizeof(esp_core_dump_summary_t)));

--- a/min_spiffs.csv
+++ b/min_spiffs.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1E0000,
+app1,     app,  ota_1,   0x1F0000,0x1E0000,
+spiffs,   data, spiffs,  0x3D0000,0x20000,
+coredump, data, coredump,0x3F0000,0x10000,

--- a/min_spiffs.csv
+++ b/min_spiffs.csv
@@ -1,7 +1,0 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-nvs,      data, nvs,     0x9000,  0x5000,
-otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x1E0000,
-app1,     app,  ota_1,   0x1F0000,0x1E0000,
-spiffs,   data, spiffs,  0x3D0000,0x20000,
-coredump, data, coredump,0x3F0000,0x10000,

--- a/partitions/default_8MB.csv
+++ b/partitions/default_8MB.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x330000,
+app1,     app,  ota_1,   0x340000,0x330000,
+spiffs,   data, spiffs,  0x670000,0x180000,
+coredump, data, coredump,0x7F0000,0x10000,

--- a/partitions/min_spiffs.csv
+++ b/partitions/min_spiffs.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1E0000,
+app1,     app,  ota_1,   0x1F0000,0x1E0000,
+spiffs,   data, spiffs,  0x3D0000,0x20000,
+coredump, data, coredump,0x3F0000,0x10000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ monitor_filters =
   ; time
 extra_scripts = pre:prebuild.py
 build_flags = 
-  -D CORE_DEBUG_LEVEL=0         # For debugging set to 3 and enable debug mode in the app
+  -D CORE_DEBUG_LEVEL=0         # For debugging set >3, use TTGO_T7S3_DEBUG and change build_type
   -D MIN_PUBLISH_INTERVAL=30    # Minimum interval between clouds updates
   -D WAIT_FOR_PM_SENSOR=25      # time of stabilization of PM sensors in seconds
   -D ARDUINO_ESP32_DEV=1        # compatibilty for DFRobot NH3/CO library
@@ -142,22 +142,13 @@ build_flags =
 
 [esp32c3_common]
 extends = oled_common
-platform = espressif32 @ 6.9.0
 board = esp32-c3-devkitm-1
 lib_deps =
   ${oled_common.lib_deps}
-build_unflags =
-  -O2
-  -O3
 build_flags =
   ${env.build_flags}
   -D DISABLE_BATT=1
   -D DISABLE_SNIFFER=1
-  -D DISABLE_CLI_TELNET=1
-  -Os
-  -ffunction-sections
-  -fdata-sections
-  -Wl,--gc-sections
   
 [env:ESP32C3]
 extends = esp32c3_common
@@ -181,6 +172,8 @@ build_flags =
   ${esp32c3_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D ARDUINO_USB_MODE=1
+  -D SLIB_I2C_SDA=8
+  -D SLIB_I2C_SCL=10
 
 [env:ESP32C3SEEDX]
 extends = esp32c3_common
@@ -198,7 +191,7 @@ build_flags =
 
 [esp32s2_common]
 extends = oled_common
-platform = espressif32 @ 6.9.0
+framework = arduino
 build_flags =
   ${env.build_flags}
   -D DISABLE_BLE=1
@@ -221,18 +214,15 @@ build_flags =
 
 [esp32s3_common]
 extends = oled_common
-platform = espressif32 @ 6.9.0
-board = esp32-s3-devkitc-1
 board_build.partitions = partitions/default_8MB.csv
 build_flags = 
   ${env.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D BOARD_HAS_PSRAM=1
-  ; -mfix-esp32-psram-cache-issue
-  ; -D MAIN_HW_EN_PIN=3          # enable the main hardware pin (main sensor)
 
 [env:ESP32S3]  
 extends = esp32s3_common
+board = esp32-s3-devkitm-1
 board_build.arduino.memory_type = dio_opi ;
 
 [env:XIAO_S3]
@@ -245,9 +235,18 @@ extends = esp32s3_common
 board = lilygo_t7s3
 build_flags =
   ${esp32s3_common.build_flags}
-  -D ARDUINO_USB_CDC_ON_BOOT=1
   -D SLIB_I2C_SDA=13
   -D SLIB_I2C_SCL=14
+
+[env:TTGO_T7S3_DEBUG]
+extends = esp32s3_common
+framework = arduino
+board = lilygo_t7s3
+build_flags =
+  ${esp32s3_common.build_flags}
+  -D SLIB_I2C_SDA=13
+  -D SLIB_I2C_SCL=14
+  -D DEBUG_MODE_NO_IDF_RULES=1
 
 ; experimental LoRa version
 [env:LORADEVKIT]

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,8 +20,8 @@ target = dev
 
 [env]
 build_type = release
-platform = espressif32 @ 4.4.0
-framework = arduino
+platform = espressif32 @ 6.9.0
+framework = arduino, espidf
 upload_speed = 1500000
 monitor_speed = 115200
 
@@ -58,16 +58,15 @@ lib_deps =
   hpsaturn/ESP32 Wifi CLI @ 0.3.5
   ; hpsaturn/CanAirIO Air Quality Sensors Library @ 0.7.6
   https://github.com/kike-canaries/canairio_sensorlib.git#devel
-  ; https://github.com/kike-canaries/canairio_sensorlib.git#sync_time_refactor
-  https://github.com/chrisjoyce911/esp32FOTA.git
-  https://github.com/rlogiacco/CircularBuffer.git
-  https://github.com/256dpi/arduino-mqtt.git
-  https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
+  https://github.com/chrisjoyce911/esp32FOTA.git#2bbc9cb
+  https://github.com/rlogiacco/CircularBuffer.git#f29cf01
+  https://github.com/256dpi/arduino-mqtt.git#7afcfb1
+  https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git#8e5f051
   ; ${env.lib_deps}  ; only for local tests of sensorslib
 
 [esp32_common]
 board = lolin32
-board_build.partitions = min_spiffs.csv
+board_build.partitions = partitions/min_spiffs.csv
 
 [oled_common]
 extends = esp32_common
@@ -162,7 +161,6 @@ build_flags =
   
 [env:ESP32C3]
 extends = esp32c3_common
-board_build.partitions = huge_app.csv
 board_build.f_flash = 40000000L
 build_flags = 
   ${env.build_flags}
@@ -176,7 +174,6 @@ board = ttgo-t-oi-plus
 [env:ESP32C3LOLIN]
 extends = esp32c3_common
 board = lolin_c3_mini
-board_build.partitions = huge_app.csv
 board_build.flash_mode = dio
 board_build.arduino.memory_type = dio_qspi
 board_build.f_flash = 40000000L
@@ -191,7 +188,6 @@ board = seeed_xiao_esp32c3
 
 [env:AG_OPENAIR]
 extends = esp32c3_common
-board_build.partitions = huge_app.csv
 board_build.f_flash = 40000000L
 build_flags = 
   ${env.build_flags}
@@ -227,6 +223,7 @@ build_flags =
 extends = oled_common
 platform = espressif32 @ 6.9.0
 board = esp32-s3-devkitc-1
+board_build.partitions = partitions/default_8MB.csv
 build_flags = 
   ${env.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
@@ -237,18 +234,15 @@ build_flags =
 [env:ESP32S3]  
 extends = esp32s3_common
 board_build.arduino.memory_type = dio_opi ;
-board_build.partitions = default_8MB.csv
 
 [env:XIAO_S3]
 extends = esp32s3_common
 board = seeed_xiao_esp32s3
 board_build.arduino.memory_type = dio_opi ;
-board_build.partitions = default_8MB.csv
 
 [env:TTGO_T7S3]
 extends = esp32s3_common
 board = lilygo_t7s3
-board_build.partitions = default_8MB.csv
 build_flags =
   ${esp32s3_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
@@ -284,32 +278,3 @@ build_flags =
   -D ARDUINO_SAMD_VARIANT_COMPLIANCE=1
   -D TTGOLORA32V1
   ;lib_ignore = gui-utils-tft
-
-[env:ESP32DEVKIT_THIN]
-extends = oled_common
-platform = espressif32 @ 6.9.0
-framework = arduino, espidf
-upload_speed = 921600
-build_flags =
-  ${env.build_flags}
-  -Wno-error=all
-build_unflags =
-  -Werror=all
-
-[env:ESP32C3LOLIN_THIN]
-extends = esp32c3_common
-platform = espressif32 @ 6.9.0
-framework = arduino, espidf
-board = lolin_c3_mini
-board_build.flash_mode = dio
-board_build.arduino.memory_type = dio_qspi
-board_build.f_flash = 40000000L
-build_unflags =
-  -O2
-  -O3
-  -Werror=all
-build_flags =
-  ${esp32c3_common.build_flags}
-  -D ARDUINO_USB_CDC_ON_BOOT=1
-  -D ARDUINO_USB_MODE=1
-  -Wno-error=all

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,10 +59,10 @@ lib_deps =
   ; hpsaturn/CanAirIO Air Quality Sensors Library @ 0.7.6
   https://github.com/kike-canaries/canairio_sensorlib.git#devel
   ; https://github.com/kike-canaries/canairio_sensorlib.git#sync_time_refactor
-  https://github.com/chrisjoyce911/esp32FOTA.git#2bbc9cb
-  https://github.com/rlogiacco/CircularBuffer.git#f29cf01
-  https://github.com/256dpi/arduino-mqtt.git#7afcfb1
-  https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git#8e5f051
+  https://github.com/chrisjoyce911/esp32FOTA.git
+  https://github.com/rlogiacco/CircularBuffer.git
+  https://github.com/256dpi/arduino-mqtt.git
+  https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
   ; ${env.lib_deps}  ; only for local tests of sensorslib
 
 [esp32_common]
@@ -249,6 +249,7 @@ board_build.partitions = default_8MB.csv
 [env:TTGO_T7S3]
 extends = esp32s3_common
 board = lilygo_t7s3
+board_build.partitions = default_8MB.csv
 build_flags =
   ${esp32s3_common.build_flags}
   -D ARDUINO_USB_CDC_ON_BOOT=1
@@ -284,3 +285,35 @@ build_flags =
   -D ARDUINO_SAMD_VARIANT_COMPLIANCE=1
   -D TTGOLORA32V1
   ;lib_ignore = gui-utils-tft
+
+[env:ESP32DEVKIT_THIN]
+extends = oled_common
+platform = espressif32 @ 6.9.0
+framework = arduino, espidf
+upload_speed = 921600
+board_build.partitions = min_spiffs.csv
+build_flags =
+  ${env.build_flags}
+  -Wno-error=all
+build_unflags =
+  -Werror=all
+
+[env:ESP32C3LOLIN_THIN]
+extends = esp32c3_common
+platform = espressif32 @ 6.9.0
+framework = arduino, espidf
+board = lolin_c3_mini
+build_type = release
+board_build.partitions = min_spiffs.csv
+board_build.flash_mode = dio
+board_build.arduino.memory_type = dio_qspi
+board_build.f_flash = 40000000L
+build_unflags =
+  -O2
+  -O3
+  -Werror=all
+build_flags =
+  ${esp32c3_common.build_flags}
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+  -Wno-error=all

--- a/platformio.ini
+++ b/platformio.ini
@@ -155,7 +155,6 @@ build_flags =
   -D DISABLE_BATT=1
   -D DISABLE_SNIFFER=1
   -D DISABLE_CLI_TELNET=1
-  -D CORE_DEBUG_LEVEL=0
   -Os
   -ffunction-sections
   -fdata-sections
@@ -291,7 +290,6 @@ extends = oled_common
 platform = espressif32 @ 6.9.0
 framework = arduino, espidf
 upload_speed = 921600
-board_build.partitions = min_spiffs.csv
 build_flags =
   ${env.build_flags}
   -Wno-error=all
@@ -303,8 +301,6 @@ extends = esp32c3_common
 platform = espressif32 @ 6.9.0
 framework = arduino, espidf
 board = lolin_c3_mini
-build_type = release
-board_build.partitions = min_spiffs.csv
 board_build.flash_mode = dio
 board_build.arduino.memory_type = dio_qspi
 board_build.f_flash = 40000000L

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -41,8 +41,8 @@ CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
 
 # La tabla de particiones debe existir EN LA RAIZ del proyecto: en este
 # modo no se busca dentro del framework. Copia min_spiffs.csv alli.
-CONFIG_PARTITION_TABLE_CUSTOM=y
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="min_spiffs.csv"
+#CONFIG_PARTITION_TABLE_CUSTOM=y
+#CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="min_spiffs.csv"
 
 # --- Bluetooth: solo BLE ---------------------------------------------
 # El sdkconfig precompilado de Arduino trae ademas Bluetooth Clasico,

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,0 +1,96 @@
+# =====================================================================
+#  CanAirIO - rama "thin"
+#  sdkconfig para el modo Arduino-como-componente-de-ESP-IDF
+#  (framework = arduino, espidf)
+#
+#  Objetivo: reducir el binario SIN desactivar ninguna funcionalidad
+#  del firmware. Todo lo que se quita aqui es codigo de la SDK que
+#  CanAirIO nunca usa.
+# =====================================================================
+
+# --- Obligatorio: arranque estilo Arduino (setup/loop) ---------------
+CONFIG_AUTOSTART_ARDUINO=y
+CONFIG_FREERTOS_HZ=1000
+
+# --- IRAM: alinear con lo que hace Arduino ---------------------------
+# ESP-IDF activa por defecto estas optimizaciones, que colocan codigo de
+# WiFi y lwIP en IRAM. Arduino las desactiva TODAS porque no caben junto
+# con Bluedroid. Sin estas lineas el enlazado falla con
+# "region iram0_0_seg overflowed".
+CONFIG_ESP32_WIFI_IRAM_OPT=n
+CONFIG_ESP32_WIFI_RX_IRAM_OPT=n
+CONFIG_ESP_WIFI_SLP_IRAM_OPT=n
+CONFIG_LWIP_IRAM_OPTIMIZATION=n
+
+# --- mbedTLS: PSK obligatorio para WiFiClientSecure ------------------
+# ssl_client.cpp del framework envuelve TODO su contenido en
+#   #if !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED) ... #else ...
+# Si PSK esta desactivado el archivo queda vacio y el enlazado falla con
+# "undefined reference to start_ssl_client / ssl_init / ...".
+# El ejemplo oficial espidf-arduino-blink incluye estas dos lineas.
+CONFIG_MBEDTLS_PSK_MODES=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
+
+# --- Flash y tabla de particiones ------------------------------------
+# En modo ESP-IDF estos valores NO se toman de la definicion de la
+# placa: hay que declararlos aqui. Por defecto ESP-IDF asume 2MB.
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
+
+# La tabla de particiones debe existir EN LA RAIZ del proyecto: en este
+# modo no se busca dentro del framework. Copia min_spiffs.csv alli.
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="min_spiffs.csv"
+
+# --- Bluetooth: solo BLE ---------------------------------------------
+# El sdkconfig precompilado de Arduino trae ademas Bluetooth Clasico,
+# A2DP (audio) y SPP (puerto serie BT). CanAirIO solo usa BLE (GATT
+# server), asi que todo eso es peso muerto. Este es el mayor ahorro.
+CONFIG_BT_ENABLED=y
+CONFIG_BT_BLUEDROID_ENABLED=y
+CONFIG_BT_CLASSIC_ENABLED=n
+CONFIG_BT_A2DP_ENABLE=n
+CONFIG_BT_SPP_ENABLED=n
+CONFIG_BT_HFP_ENABLE=n
+
+# BLE: se dejan activos GATTS (servidor, lo que usa bluetooth.cpp),
+# GATTC y SMP porque la libreria BLE de Arduino compila BLEClient.cpp
+# y BLESecurity.cpp; desactivarlos provoca errores de enlazado.
+CONFIG_BT_BLE_ENABLED=y
+CONFIG_BT_GATTS_ENABLE=y
+CONFIG_BT_GATTC_ENABLE=y
+CONFIG_BT_BLE_SMP_ENABLE=y
+
+# Chips con BLE 5.0 (C3, S3): ESP-IDF parte la API de GAP en heredada
+# (4.2) y extendida (5.0), y por defecto solo activa la de 5.0. La
+# libreria BLE de Arduino usa la de 4.2 (esp_ble_gap_config_adv_data,
+# esp_ble_gap_start_advertising), asi que hay que activar las dos.
+# En el ESP32 clasico estas claves no existen y se ignoran.
+CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
+CONFIG_BT_BLE_50_FEATURES_SUPPORTED=y
+
+# Pila de la tarea BTC. En ESP32 clasico ya son 8192 por defecto; se
+# fija explicitamente para que no dependa del target (en C3/S3 el
+# valor por defecto son 3072, origen del stack overflow del PR #347).
+CONFIG_BT_BTC_TASK_STACK_SIZE=8192
+
+# --- Consola (relevante en C3: USB-CDC on boot) ----------------------
+# Arduino deja la consola de IDF en UART0 y el USB Serial JTAG como
+# secundario; Serial lo gestiona la clase HWCDC de Arduino.
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+
+# --- Grasa de compilacion (no afecta a funcionalidad) ----------------
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
+CONFIG_LOG_DEFAULT_LEVEL_ERROR=y
+
+# Tabla de nombres legibles de codigos de error (esp_err_to_name).
+# Solo se usa para imprimir mensajes; quitarla libera unos KB.
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
+
+# Heap poisoning: comprobaciones de depuracion del heap.
+# Quitalo solo cuando el firmware este estable.
+CONFIG_HEAP_POISONING_DISABLE=y

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,53 +1,46 @@
 # =====================================================================
-#  CanAirIO - rama "thin"
-#  sdkconfig para el modo Arduino-como-componente-de-ESP-IDF
+#  CanAirIO - "thin" branch
+#  sdkconfig for Arduino-as-ESP-IDF-component mode
 #  (framework = arduino, espidf)
 #
-#  Objetivo: reducir el binario SIN desactivar ninguna funcionalidad
-#  del firmware. Todo lo que se quita aqui es codigo de la SDK que
-#  CanAirIO nunca usa.
+#  Goal: reduce binary size WITHOUT disabling any firmware functionality.
+#  Everything removed here is SDK code that CanAirIO never uses.
 # =====================================================================
 
-# --- Obligatorio: arranque estilo Arduino (setup/loop) ---------------
+# --- Mandatory: Arduino-style boot (setup/loop) ----------------------
 CONFIG_AUTOSTART_ARDUINO=y
 CONFIG_FREERTOS_HZ=1000
 
-# --- IRAM: alinear con lo que hace Arduino ---------------------------
-# ESP-IDF activa por defecto estas optimizaciones, que colocan codigo de
-# WiFi y lwIP en IRAM. Arduino las desactiva TODAS porque no caben junto
-# con Bluedroid. Sin estas lineas el enlazado falla con
-# "region iram0_0_seg overflowed".
+# --- IRAM: align with Arduino defaults -------------------------------
+# ESP-IDF enables WiFi and lwIP IRAM optimizations by default.
+# Arduino disables ALL of them because they don't fit alongside Bluedroid.
+# Without these lines, linking fails with "region iram0_0_seg overflowed".
 CONFIG_ESP32_WIFI_IRAM_OPT=n
 CONFIG_ESP32_WIFI_RX_IRAM_OPT=n
 CONFIG_ESP_WIFI_SLP_IRAM_OPT=n
 CONFIG_LWIP_IRAM_OPTIMIZATION=n
 
-# --- mbedTLS: PSK obligatorio para WiFiClientSecure ------------------
-# ssl_client.cpp del framework envuelve TODO su contenido en
+# --- mbedTLS: PSK required for WiFiClientSecure ----------------------
+# ssl_client.cpp from the framework wraps all its content inside
 #   #if !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED) ... #else ...
-# Si PSK esta desactivado el archivo queda vacio y el enlazado falla con
+# If PSK is disabled, the file becomes empty and linking fails with
 # "undefined reference to start_ssl_client / ssl_init / ...".
-# El ejemplo oficial espidf-arduino-blink incluye estas dos lineas.
+# The official espidf-arduino-blink example includes these two lines.
 CONFIG_MBEDTLS_PSK_MODES=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
 
-# --- Flash y tabla de particiones ------------------------------------
-# En modo ESP-IDF estos valores NO se toman de la definicion de la
-# placa: hay que declararlos aqui. Por defecto ESP-IDF asume 2MB.
+# --- Flash and partition table ---------------------------------------
+# In ESP-IDF mode these values are NOT taken from the board definition;
+# they must be declared here. ESP-IDF defaults to 2MB.
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
 CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
 CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
 
-# La tabla de particiones debe existir EN LA RAIZ del proyecto: en este
-# modo no se busca dentro del framework. Copia min_spiffs.csv alli.
-#CONFIG_PARTITION_TABLE_CUSTOM=y
-#CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="min_spiffs.csv"
-
-# --- Bluetooth: solo BLE ---------------------------------------------
-# El sdkconfig precompilado de Arduino trae ademas Bluetooth Clasico,
-# A2DP (audio) y SPP (puerto serie BT). CanAirIO solo usa BLE (GATT
-# server), asi que todo eso es peso muerto. Este es el mayor ahorro.
+# --- Bluetooth: BLE only ---------------------------------------------
+# Arduino's precompiled sdkconfig also enables Classic Bluetooth,
+# A2DP (audio) and SPP (BT serial). CanAirIO only uses BLE (GATT
+# server), so all of that is dead weight. This is the biggest saving.
 CONFIG_BT_ENABLED=y
 CONFIG_BT_BLUEDROID_ENABLED=y
 CONFIG_BT_CLASSIC_ENABLED=n
@@ -55,42 +48,42 @@ CONFIG_BT_A2DP_ENABLE=n
 CONFIG_BT_SPP_ENABLED=n
 CONFIG_BT_HFP_ENABLE=n
 
-# BLE: se dejan activos GATTS (servidor, lo que usa bluetooth.cpp),
-# GATTC y SMP porque la libreria BLE de Arduino compila BLEClient.cpp
-# y BLESecurity.cpp; desactivarlos provoca errores de enlazado.
+# BLE: keep GATTS (server, used by bluetooth.cpp), GATTC and SMP
+# enabled because the Arduino BLE library compiles BLEClient.cpp
+# and BLESecurity.cpp; disabling them causes link errors.
 CONFIG_BT_BLE_ENABLED=y
 CONFIG_BT_GATTS_ENABLE=y
 CONFIG_BT_GATTC_ENABLE=y
 CONFIG_BT_BLE_SMP_ENABLE=y
 
-# Chips con BLE 5.0 (C3, S3): ESP-IDF parte la API de GAP en heredada
-# (4.2) y extendida (5.0), y por defecto solo activa la de 5.0. La
-# libreria BLE de Arduino usa la de 4.2 (esp_ble_gap_config_adv_data,
-# esp_ble_gap_start_advertising), asi que hay que activar las dos.
-# En el ESP32 clasico estas claves no existen y se ignoran.
+# BLE 5.0 chips (C3, S3): ESP-IDF splits the GAP API into legacy
+# (4.2) and extended (5.0), enabling only 5.0 by default. The
+# Arduino BLE library uses the 4.2 API (esp_ble_gap_config_adv_data,
+# esp_ble_gap_start_advertising), so both must be enabled.
+# On classic ESP32 these keys do not exist and are ignored.
 CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
 CONFIG_BT_BLE_50_FEATURES_SUPPORTED=y
 
-# Pila de la tarea BTC. En ESP32 clasico ya son 8192 por defecto; se
-# fija explicitamente para que no dependa del target (en C3/S3 el
-# valor por defecto son 3072, origen del stack overflow del PR #347).
+# BTC task stack size. Classic ESP32 defaults to 8192; set it
+# explicitly so it does not depend on the target (C3/S3 default
+# is 3072, which caused the stack overflow in PR #347).
 CONFIG_BT_BTC_TASK_STACK_SIZE=8192
 
-# --- Consola (relevante en C3: USB-CDC on boot) ----------------------
-# Arduino deja la consola de IDF en UART0 y el USB Serial JTAG como
-# secundario; Serial lo gestiona la clase HWCDC de Arduino.
+# --- Console (relevant on C3: USB-CDC on boot) -----------------------
+# Arduino leaves the IDF console on UART0 and USB Serial JTAG as
+# secondary; Serial is managed by Arduino's HWCDC class.
 CONFIG_ESP_CONSOLE_UART_DEFAULT=y
 CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
 
-# --- Grasa de compilacion (no afecta a funcionalidad) ----------------
+# --- Compilation trimming (no functional impact) ----------------------
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
 CONFIG_LOG_DEFAULT_LEVEL_ERROR=y
 
-# Tabla de nombres legibles de codigos de error (esp_err_to_name).
-# Solo se usa para imprimir mensajes; quitarla libera unos KB.
+# Human-readable error code table (esp_err_to_name).
+# Only used for printing messages; removing it frees a few KB.
 CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
 
-# Heap poisoning: comprobaciones de depuracion del heap.
-# Quitalo solo cuando el firmware este estable.
+# Heap poisoning: debug heap checks.
+# Only disable when the firmware is stable.
 CONFIG_HEAP_POISONING_DISABLE=y

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -32,10 +32,10 @@ CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
 # --- Flash and partition table ---------------------------------------
 # In ESP-IDF mode these values are NOT taken from the board definition;
 # they must be declared here. ESP-IDF defaults to 2MB.
-CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
-CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
-CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
-CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
+#CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+#CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+#CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+#CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
 
 # --- Bluetooth: BLE only ---------------------------------------------
 # Arduino's precompiled sdkconfig also enables Classic Bluetooth,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+# This file was automatically generated for projects
+# without default 'CMakeLists.txt' file.
+
+FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
+
+idf_component_register(SRCS ${app_sources})

--- a/src/src_CMakeLists.txt
+++ b/src/src_CMakeLists.txt
@@ -1,0 +1,4 @@
+# Este archivo va en src/CMakeLists.txt
+# src/ solo contiene main.cpp; las carpetas de lib/ las sigue
+# gestionando el Library Dependency Finder de PlatformIO.
+idf_component_register(SRCS "main.cpp" INCLUDE_DIRS ".")


### PR DESCRIPTION
## Summary

This PR reduce the firmware size on all variants using rules for IDF. Now we have 30% of free space on old cores and also using Espressif framework 6.9.0 on them. This before was impossible. On ESP32C3 we have 20% of free space, that means that old boards with 4Mb can use BLE, Telnet and CLI. 

Many thanks to @roberbike for this research.

## Bugs

- [x] OLED on C3 fixed
- [x] Some warnings are crashing the compiler in ESP32 core
- [x] Sensors working
- [x] S2 issue fixed 
- [x] Wokwi build fails with 6.9.0 

## Tested

- [x] esp32 TTGO_T7
- [x] esp32s2 LOLIN mini
- [x] esp32c3 LOLIN mini
- [x] esp32s3 TTGO_T7S3
- [ ] XIAO S3
- [ ] ESP32DevKit
 